### PR TITLE
fix: resolve QA issues #17-#21 (tests, comments, docs)

### DIFF
--- a/gpu_backend.h
+++ b/gpu_backend.h
@@ -211,6 +211,8 @@ extern cl_int (*rc_clSetKernelArg)(cl_kernel, cl_uint, size_t, const void *);
 #define CLCREATEARG(_arg_index, _buffer, _flags, _arg, _arg_size) \
   _CLCREATEARG(_arg_index, _buffer, _flags, &_arg, _arg_size);
 
+/* CLCREATEARG_DEBUG allocates *_debug_ptr internally via calloc.
+ * Do NOT pre-allocate _debug_ptr before calling this macro. */
 #define CLCREATEARG_DEBUG(_arg_index, _debug_buffer, _debug_ptr) \
   { _debug_ptr = calloc(DEBUG_LEN, sizeof(unsigned char)); \
     CLCREATEARG_ARRAY(_arg_index, _debug_buffer, GPU_RW, _debug_ptr, DEBUG_LEN); }
@@ -268,6 +270,8 @@ extern cl_int (*rc_clSetKernelArg)(cl_kernel, cl_uint, size_t, const void *);
 #define CLCREATEARG(_arg_index, _buffer, _flags, _arg, _arg_size) \
   _CLCREATEARG(_arg_index, _buffer, _flags, &_arg, _arg_size);
 
+/* CLCREATEARG_DEBUG allocates *_debug_ptr internally via calloc.
+ * Do NOT pre-allocate _debug_ptr before calling this macro. */
 #define CLCREATEARG_DEBUG(_arg_index, _debug_buffer, _debug_ptr) \
   { _debug_ptr = calloc(DEBUG_LEN, sizeof(unsigned char)); \
     CLCREATEARG_ARRAY(_arg_index, _debug_buffer, CL_MEM_READ_WRITE, _debug_ptr, DEBUG_LEN); }

--- a/test_chain_netntlmv1.c
+++ b/test_chain_netntlmv1.c
@@ -74,6 +74,8 @@ static uint64_t cpu_netntlmv1_chain(uint64_t start, unsigned int chain_len,
                            7, 7, pspace_up_to, plaintext, &plaintext_len);
         setup_des_key(plaintext, key);
         netntlmv1_hash(key, 8, hash);
+        /* pos is the 0-based intra-chain step; reduction_offset carries the
+         * table-level offset (table_index * 65536).  Both are separate. */
         index = hash_to_index(hash, 8, reduction_offset, pspace_total, pos);
     }
 

--- a/test_hash_netntlmv1.c
+++ b/test_hash_netntlmv1.c
@@ -143,9 +143,11 @@ int test_hash_netntlmv1(gpu_device device, gpu_context context, gpu_kernel kerne
         unsigned char cpu_hash[8] = {0};
         char cpu_hex[17] = {0};
 
-        /* Verify the DES key expansion contract: setup_des_key must produce
-         * an 8-byte key that differs from the raw 7-byte plaintext (the
-         * expansion spreads 56 bits across 64 bits with parity). */
+        /* Smoke test: verify setup_des_key transforms the input.
+         * This catches a completely broken DES expansion but is not a full
+         * correctness check (a pathological input could produce identical
+         * first 7 bytes after expansion).  The primary correctness assertion
+         * is the GPU vs CPU hash comparison below. */
         {
             unsigned char expanded[8] = {0};
             setup_des_key((char *)input, expanded);

--- a/test_hash_to_index_netntlmv1.c
+++ b/test_hash_to_index_netntlmv1.c
@@ -37,6 +37,10 @@ static struct h2i_test netntlmv1_h2i_tests[] = {
     {"deadbeefcafe1234", 95, 7, 7, 3,   0},
     {"0102030405060708", 95, 7, 7, 5, 750},
     {"ffeeddccbbaa9988", 95, 7, 7, 0,   0},
+    /* digits-only charset (len=10): exercises a smaller pspace_total and
+     * different modular reduction path compared to the ascii-32-95 vectors. */
+    {"aabbccddeeff0011", 10, 7, 7, 0,   5},
+    {"deadbeefcafe1234", 10, 7, 7, 2,  50},
 };
 
 

--- a/test_mask.c
+++ b/test_mask.c
@@ -414,7 +414,8 @@ static int group_e(void)
     fill_plaintext_space_table_mask(lens3, 3, pspace);
     if (pspace[3] != 1000) { fprintf(stderr, "FP-03a: pspace[3]=%"PRIu64"\n", pspace[3]); ok = 0; }
     if (pspace[2] != 0)    { fprintf(stderr, "FP-03b: pspace[2]=%"PRIu64"\n", pspace[2]); ok = 0; }
-    if (pspace[0] != 0)    { fprintf(stderr, "FP-03c: pspace[0]=%"PRIu64"\n", pspace[0]); ok = 0; }
+    if (pspace[1] != 0)    { fprintf(stderr, "FP-03c: pspace[1]=%"PRIu64"\n", pspace[1]); ok = 0; }
+    if (pspace[0] != 0)    { fprintf(stderr, "FP-03d: pspace[0]=%"PRIu64"\n", pspace[0]); ok = 0; }
 
     /* FP-04: single ?a (95) */
     unsigned int lens4[] = {95};
@@ -434,14 +435,17 @@ static int group_e(void)
     fill_plaintext_space_table_mask(lens6, 3, pspace);
     if (pspace[3] != 6760) { fprintf(stderr, "FP-06a: pspace[3]=%"PRIu64"\n", pspace[3]); ok = 0; }
     if (pspace[2] != 0)    { fprintf(stderr, "FP-06b: pspace[2]=%"PRIu64"\n", pspace[2]); ok = 0; }
-    if (pspace[0] != 0)    { fprintf(stderr, "FP-06c: pspace[0]=%"PRIu64"\n", pspace[0]); ok = 0; }
+    if (pspace[1] != 0)    { fprintf(stderr, "FP-06c: pspace[1]=%"PRIu64"\n", pspace[1]); ok = 0; }
+    if (pspace[0] != 0)    { fprintf(stderr, "FP-06d: pspace[0]=%"PRIu64"\n", pspace[0]); ok = 0; }
 
     /* FP-07: ?u?l?d?s (26*26*10*33=223080) */
     unsigned int lens7[] = {26, 26, 10, 33};
     fill_plaintext_space_table_mask(lens7, 4, pspace);
     if (pspace[4] != 223080) { fprintf(stderr, "FP-07a: pspace[4]=%"PRIu64"\n", pspace[4]); ok = 0; }
     if (pspace[3] != 0)      { fprintf(stderr, "FP-07b: pspace[3]=%"PRIu64"\n", pspace[3]); ok = 0; }
-    if (pspace[0] != 0)      { fprintf(stderr, "FP-07c: pspace[0]=%"PRIu64"\n", pspace[0]); ok = 0; }
+    if (pspace[2] != 0)      { fprintf(stderr, "FP-07c: pspace[2]=%"PRIu64"\n", pspace[2]); ok = 0; }
+    if (pspace[1] != 0)      { fprintf(stderr, "FP-07d: pspace[1]=%"PRIu64"\n", pspace[1]); ok = 0; }
+    if (pspace[0] != 0)      { fprintf(stderr, "FP-07e: pspace[0]=%"PRIu64"\n", pspace[0]); ok = 0; }
 
     /* FP-08: single ?b (256) */
     unsigned int lens8[] = {256};


### PR DESCRIPTION
Fixes #17, #18, #19, #20, #21.

## Changes

- **#17** - Added two digits-only charset (`len=10`) test vectors to `test_hash_to_index_netntlmv1.c` to exercise a smaller `pspace_total` and a different modular reduction path from the existing `charset_len=95` vectors.
- **#18** - Added inline comment in `test_chain_netntlmv1.c` at the `hash_to_index` call clarifying that `pos` is the 0-based intra-chain step, separate from `reduction_offset` (which carries the table-level offset).
- **#19** - Added `pspace[1]` assertions for FP-03/FP-06 and `pspace[1]`/`pspace[2]` assertions for FP-07 in `test_mask.c` group_e, pinning down the complete expected layout of `fill_plaintext_space_table_mask` for 3- and 4-position masks.
- **#20** - Replaced the DES expansion check comment in `test_hash_netntlmv1.c` with a note that it is a smoke test only; the primary correctness assertion is the GPU vs CPU hash comparison.
- **#21** - Added ownership comment to both Metal and OpenCL `CLCREATEARG_DEBUG` variants in `gpu_backend.h` documenting that the macro owns the `debug_ptr` allocation and callers must not pre-allocate it.

## Test plan
- [x] Each fix built and tested individually with `make macos` + `./crackalack_unit_tests`
- [x] ALL UNIT TESTS PASS after every change