### PR TITLE
fix: resolve issues #23-#40 (tests, docs, bug fixes)

### DIFF
--- a/cpu_rt_functions.c
+++ b/cpu_rt_functions.c
@@ -30,6 +30,11 @@
 
 
 
+/* Fills the pspace table for a mask charset.
+ * Invariant: pspace[0..mask_length-1] are always 0; pspace[mask_length] is the
+ * total keyspace.  index_to_plaintext_mask relies on pspace[mask_length-1]==0
+ * so that index_x = index - 0 = index.  Do not change this layout without
+ * updating index_to_plaintext_mask. */
 uint64_t fill_plaintext_space_table_mask(unsigned int *mask_lens, unsigned int mask_length, uint64_t *plaintext_space_up_to_index) {
   uint64_t product = 1;
   int i;
@@ -120,6 +125,9 @@ void index_to_plaintext_mask(uint64_t index, unsigned int *mask_lens, char *mask
   *plaintext_len = mask_length;
   plaintext[mask_length] = '\0';
 
+  /* pspace[mask_length-1] is always 0 (see fill_plaintext_space_table_mask
+   * invariant), so index_x == index.  Do not remove the subtraction: it is
+   * the documented interface with fill_plaintext_space_table_mask. */
   index_x = index - plaintext_space_up_to_index[mask_length - 1];
   for (i = (int)mask_length - 1; i >= 0; i--) {
     unsigned int sz = mask_lens[i];

--- a/gpu_backend.h
+++ b/gpu_backend.h
@@ -220,8 +220,11 @@ extern cl_int (*rc_clSetKernelArg)(cl_kernel, cl_uint, size_t, const void *);
 #define CLCREATECONTEXT(_context_callback, _device_ptr) \
   gpu_create_context(*(_device_ptr))
 
+/* Suppress -Wunused-variable for 'err' (defined in CLMAKETESTVARS): Metal's
+ * gpu_create_queue returns the queue directly rather than setting an error
+ * code, so err is only written later by CLRUNKERNEL/CLFLUSH/CLWAIT. */
 #define CLCREATEQUEUE(_context, _device) \
-  gpu_create_queue(_context, _device)
+  ((void)err, gpu_create_queue(_context, _device))
 
 #define CLRUNKERNEL(_queue, _kernel, _gws_ptr) \
   { err = gpu_enqueue_kernel(_queue, _kernel, 1, _gws_ptr); if (err != 0) { fprintf(stderr, "gpu_enqueue_kernel failed: %d\n", err); exit(-1); } }

--- a/mask_parse.c
+++ b/mask_parse.c
@@ -119,6 +119,10 @@ int mask_parse(const char *mask_str, Mask *out,
 }
 
 
+/* Returns the total keyspace of a mask (product of all position sizes).
+ * Precondition: m->length > 0.  A zero-length mask returns 1 (not 0) because
+ * mask_parse rejects empty masks before this function is called.  Callers that
+ * construct a Mask struct directly must ensure m->length > 0. */
 uint64_t mask_keyspace(const Mask *m) {
     uint64_t product = 1;
     int i;

--- a/shared.h
+++ b/shared.h
@@ -16,7 +16,9 @@
 
 #define DEBUG_LEN 32
 
-/* Converts a table index to a reduction offset. */
+/* Converts a table index to a reduction offset.
+ * reduction_offset is unsigned int (32-bit).  table_index must be <= 65535;
+ * values >= 65536 cause silent 32-bit unsigned overflow. */
 #define TABLE_INDEX_TO_REDUCTION_OFFSET(_table_index) (_table_index * 65536)
 
 #endif

--- a/test_chain_netntlmv1.c
+++ b/test_chain_netntlmv1.c
@@ -26,25 +26,37 @@ struct netntlmv1_chain_test {
     uint64_t start;
     unsigned int chain_len;
     unsigned int table_index;
+    const char *charset;
+    unsigned int charset_len;
+    unsigned int plaintext_len; /* min == max for NetNTLMv1 tables */
 };
 
-/* Short chains using ascii-32-95 with 7-char plaintexts.
- * Includes low table_index values (0, 1) for basic coverage and high
- * table_index values (100, 1000) to exercise large reduction offsets
- * (table_index * 65536) which stress the hash_to_index modular reduction. */
+/* ascii-32-95 7-char chain tests.
+ * Includes low table_index (0, 1) for basic coverage and high table_index
+ * (100, 1000) to exercise large reduction offsets (table_index * 65536).
+ * chain_len=1 is a degenerate case: 0 hash+reduce steps, end==start.
+ * The high start index (69833729609374) is pspace_total-1 for 7-char
+ * ascii-32-95 (95^7), exercising the upper plaintext space boundary. */
 static struct netntlmv1_chain_test netntlmv1_chain_tests[] = {
-    {0UL,   100, 0},
-    {999UL, 100, 0},
-    {0UL,   200, 1},
-    {0UL,   100, 100},
-    {500UL, 150, 1000},
+    {0UL,              100,  0, CHARSET_ASCII_32_95, CHARSET_ASCII_32_95_LEN, 7},
+    {999UL,            100,  0, CHARSET_ASCII_32_95, CHARSET_ASCII_32_95_LEN, 7},
+    {0UL,              200,  1, CHARSET_ASCII_32_95, CHARSET_ASCII_32_95_LEN, 7},
+    {0UL,              100,  100, CHARSET_ASCII_32_95, CHARSET_ASCII_32_95_LEN, 7},
+    {500UL,            150,  1000, CHARSET_ASCII_32_95, CHARSET_ASCII_32_95_LEN, 7},
+    /* chain_len=1: loop runs 0 iterations, end must equal start */
+    {42UL,               1,    0, CHARSET_ASCII_32_95, CHARSET_ASCII_32_95_LEN, 7},
+    /* high start near top of 7-char ascii-32-95 space (95^7 - 1) */
+    {69833729609374UL, 100,    0, CHARSET_ASCII_32_95, CHARSET_ASCII_32_95_LEN, 7},
+    /* digits-only, 3-char plaintexts: pspace=1000, different modular reduction */
+    {0UL,               50,    0, CHARSET_NUMERIC, CHARSET_NUMERIC_LEN, 3},
+    {500UL,             50,    1, CHARSET_NUMERIC, CHARSET_NUMERIC_LEN, 3},
 };
 
 
 /*
  * CPU reference NetNTLMv1 chain generator.
- * Mirrors the GPU crackalack kernel for HASH_NETNTLMV1 with ascii-32-95 7-char
- * tables using index_to_plaintext + setup_des_key + netntlmv1_hash + hash_to_index.
+ * Mirrors the GPU crackalack kernel for HASH_NETNTLMV1 using
+ * index_to_plaintext + setup_des_key + netntlmv1_hash + hash_to_index.
  *
  * The loop runs chain_len-1 iterations (not chain_len) because a rainbow chain
  * of length N has N links but only N-1 hash+reduce steps: the start point is
@@ -53,7 +65,10 @@ static struct netntlmv1_chain_test netntlmv1_chain_tests[] = {
  * crackalack kernel which also iterates from pos_start to chain_len-1.
  */
 static uint64_t cpu_netntlmv1_chain(uint64_t start, unsigned int chain_len,
-                                     unsigned int table_index)
+                                     unsigned int table_index,
+                                     const char *charset,
+                                     unsigned int charset_len,
+                                     unsigned int plaintext_len_val)
 {
     uint64_t pspace_up_to[MAX_PLAINTEXT_LEN] = {0};
     uint64_t pspace_total;
@@ -61,17 +76,20 @@ static uint64_t cpu_netntlmv1_chain(uint64_t start, unsigned int chain_len,
     unsigned int pos;
     unsigned int reduction_offset = TABLE_INDEX_TO_REDUCTION_OFFSET(table_index);
 
-    pspace_total = fill_plaintext_space_table(CHARSET_ASCII_32_95_LEN, 7, 7,
+    pspace_total = fill_plaintext_space_table(charset_len,
+                                              plaintext_len_val,
+                                              plaintext_len_val,
                                               pspace_up_to);
 
     for (pos = 0; pos < chain_len - 1; pos++) {
         char plaintext[MAX_PLAINTEXT_LEN] = {0};
-        unsigned int plaintext_len = 0;
+        unsigned int pl = 0;
         unsigned char key[8] = {0};
         unsigned char hash[8] = {0};
 
-        index_to_plaintext(index, CHARSET_ASCII_32_95, CHARSET_ASCII_32_95_LEN,
-                           7, 7, pspace_up_to, plaintext, &plaintext_len);
+        index_to_plaintext(index, (char *)charset, charset_len,
+                           plaintext_len_val, plaintext_len_val,
+                           pspace_up_to, plaintext, &pl);
         setup_des_key(plaintext, key);
         netntlmv1_hash(key, 8, hash);
         /* pos is the 0-based intra-chain step; reduction_offset carries the
@@ -93,7 +111,8 @@ static int gpu_test_netntlmv1_chain(gpu_device device, gpu_context context,
     int test_passed = 0;
 
     gpu_uint hash_type = HASH_NETNTLMV1;
-    gpu_uint plaintext_len_min = 7, plaintext_len_max = 7;
+    gpu_uint plaintext_len_min = t->plaintext_len;
+    gpu_uint plaintext_len_max = t->plaintext_len;
     gpu_uint reduction_offset =
         TABLE_INDEX_TO_REDUCTION_OFFSET(t->table_index);
     gpu_uint chain_len = t->chain_len;
@@ -105,8 +124,9 @@ static int gpu_test_netntlmv1_chain(gpu_device device, gpu_context context,
     gpu_ulong pspace_total = 0;
     {
         uint64_t tmp[MAX_PLAINTEXT_LEN] = {0};
-        uint64_t tot = fill_plaintext_space_table(CHARSET_ASCII_32_95_LEN,
-                                                   7, 7, tmp);
+        uint64_t tot = fill_plaintext_space_table(t->charset_len,
+                                                   t->plaintext_len,
+                                                   t->plaintext_len, tmp);
         int k;
         for (k = 0; k < MAX_PLAINTEXT_LEN; k++)
             pspace_up_to[k] = (gpu_ulong)tmp[k];
@@ -136,7 +156,7 @@ static int gpu_test_netntlmv1_chain(gpu_device device, gpu_context context,
 
     CLCREATEARG(0, hash_type_buf, CL_RO, hash_type, sizeof(hash_type));
     CLCREATEARG_ARRAY(1, charset_buf, CL_RO,
-                      CHARSET_ASCII_32_95, CHARSET_ASCII_32_95_LEN + 1);
+                      t->charset, t->charset_len + 1);
     CLCREATEARG(2, len_min_buf, CL_RO, plaintext_len_min, sizeof(plaintext_len_min));
     CLCREATEARG(3, len_max_buf, CL_RO, plaintext_len_max, sizeof(plaintext_len_max));
     CLCREATEARG(4, reduc_buf, CL_RO, reduction_offset, sizeof(reduction_offset));
@@ -198,7 +218,9 @@ int test_chain_netntlmv1(gpu_device device, gpu_context context, gpu_kernel kern
     for (i = 0; i < num_tests; i++) {
         const struct netntlmv1_chain_test *t = &netntlmv1_chain_tests[i];
         uint64_t cpu_end = cpu_netntlmv1_chain(t->start, t->chain_len,
-                                                t->table_index);
+                                                t->table_index,
+                                                t->charset, t->charset_len,
+                                                t->plaintext_len);
         tests_passed &= gpu_test_netntlmv1_chain(device, context, kernel,
                                                   t, cpu_end);
     }

--- a/test_hash_netntlmv1.c
+++ b/test_hash_netntlmv1.c
@@ -30,13 +30,17 @@
 #include "test_hash_netntlmv1.h"
 
 
-/* 7-byte plaintexts used as DES keys in NetNTLMv1 tables. */
+/* 7-byte plaintexts used as DES keys in NetNTLMv1 tables.
+ * "\x01\x01\x01\x01\x01\x01\x01" exercises a zero byte in the expanded DES
+ * key (setup_des_key maps 0x01 to key[0]=0x00) without triggering the smoke
+ * test's false-positive guard for identical raw/expanded keys. */
 static const char *netntlmv1_test_inputs[] = {
     "abcdefg",
     "1234567",
     "ABCDEFG",
     "passwd1",
     " !#$%&(",
+    "\x01\x01\x01\x01\x01\x01\x01",
 };
 
 

--- a/test_hash_to_index_netntlmv1.c
+++ b/test_hash_to_index_netntlmv1.c
@@ -41,6 +41,10 @@ static struct h2i_test netntlmv1_h2i_tests[] = {
      * different modular reduction path compared to the ascii-32-95 vectors. */
     {"aabbccddeeff0011", 10, 7, 7, 0,   5},
     {"deadbeefcafe1234", 10, 7, 7, 2,  50},
+    /* Large pos values: push (ret + reduction_offset + pos) toward real table
+     * usage.  NTLM9 tables have chain_len=803000, so pos can reach 802999. */
+    {"aabbccddeeff0011", 95, 7, 7, 0, 65535},
+    {"deadbeefcafe1234", 95, 7, 7, 0, 802999},
 };
 
 
@@ -64,6 +68,12 @@ static int gpu_test_netntlmv1_h2i(gpu_device device, gpu_context context,
     gpu_ulong *index_ptr = NULL;
     unsigned char *debug_ptr = NULL;
 
+    index_ptr = calloc(1, sizeof(gpu_ulong));
+    if (!index_ptr) {
+        fprintf(stderr, "Error allocating index buffer in test_hash_to_index_netntlmv1\n");
+        exit(-1);
+    }
+
     queue = CLCREATEQUEUE(context, device);
 
     hash_len = hex_to_bytes((char *)t->hash, sizeof(hash_bytes), hash_bytes);
@@ -83,12 +93,6 @@ static int gpu_test_netntlmv1_h2i(gpu_device device, gpu_context context,
     CLRUNKERNEL(queue, kernel, &global_work_size);
     CLFLUSH(queue);
     CLWAIT(queue);
-
-    index_ptr = calloc(1, sizeof(gpu_ulong));
-    if (!index_ptr) {
-        fprintf(stderr, "Error allocating index buffer in test_hash_to_index_netntlmv1\n");
-        exit(-1);
-    }
 
     CLREADBUFFER(index_buffer, sizeof(gpu_ulong), index_ptr);
 

--- a/test_mask.c
+++ b/test_mask.c
@@ -530,12 +530,17 @@ static int group_f(void)
         ok = 0;
     }
 
-    /* VR-07: mask table for lookup type - unsorted ends must be rejected. */
+    /* VR-07: mask table for lookup type - unsorted ends must be rejected.
+     * ends: 5, 3 - chain 1's end (3) < chain 0's end (5), so error_chain==1. */
     uint64_t unsorted_lookup[4] = { 7, 5,   3, 3 }; /* ends: 5, 3 - not sorted */
     error_chain = 99;
     if (verify_rainbowtable(unsorted_lookup, 2, VERIFY_TABLE_TYPE_LOOKUP,
                             0, 10000, &error_chain, 1)) {
         fprintf(stderr, "VR-07 failed: unsorted lookup table should be rejected\n");
+        ok = 0;
+    }
+    if (error_chain != 1) {
+        fprintf(stderr, "VR-07b: error_chain expected 1, got %u\n", error_chain);
         ok = 0;
     }
 
@@ -571,6 +576,26 @@ static int group_f(void)
         ok = 0;
     }
 
+    /* VR-11: num_chains=0 - the loop never executes so verify_rainbowtable
+     * returns 1 (valid empty table).  Explicitly document this behaviour. */
+    error_chain = 99;
+    if (!verify_rainbowtable(NULL, 0, VERIFY_TABLE_TYPE_GENERATED,
+                             0, 10000, &error_chain, 0)) {
+        fprintf(stderr, "VR-11 failed: empty table (num_chains=0) should pass\n");
+        ok = 0;
+    }
+
+    /* VR-12: plaintext_space_total=0 - bounds checks are skipped when the
+     * total is zero (the guard at verify.c:65 requires pst > 0).  The table
+     * should still pass structural checks. */
+    uint64_t vr12_chains[4] = { 0, 1,   1, 2 };
+    error_chain = 99;
+    if (!verify_rainbowtable(vr12_chains, 2, VERIFY_TABLE_TYPE_GENERATED,
+                             0, 0, &error_chain, 0)) {
+        fprintf(stderr, "VR-12 failed: pspace_total=0 should skip bounds check and pass\n");
+        ok = 0;
+    }
+
     return ok;
 }
 
@@ -596,13 +621,26 @@ static int group_g(void)
     if (strcmp(buf, "nospecifiers") != 0)
         { fprintf(stderr, "ME-03 failed: got \"%s\"\n", buf); ok = 0; }
 
-    /* ME-04 through ME-13: round-trip for all built-in specifiers */
+    /* ME-04 through ME-13: round-trip for all built-in specifiers.
+     * Also verify the encoded form directly: '?' must become '%' so that the
+     * filename-safety guarantee holds independent of round-trip symmetry. */
     const char *specifiers[] = {"?l","?u","?d","?s","?a","?b","?1","?2","?3","?4"};
     unsigned int n = (unsigned int)(sizeof(specifiers) / sizeof(specifiers[0]));
     for (unsigned int i = 0; i < n; i++) {
         char encoded[8];
         char decoded[8];
         mask_encode_for_filename(specifiers[i], encoded, sizeof(encoded));
+        /* Direct check: '?' must be encoded as '%' and the specifier char preserved. */
+        if (encoded[0] != '%') {
+            fprintf(stderr, "ME-%02u encode failed: first char is '%c', expected '%%'\n",
+                    4 + i, encoded[0]);
+            ok = 0;
+        }
+        if (encoded[1] != specifiers[i][1]) {
+            fprintf(stderr, "ME-%02u encode failed: specifier char is '%c', expected '%c'\n",
+                    4 + i, encoded[1], specifiers[i][1]);
+            ok = 0;
+        }
         strncpy(decoded, encoded, sizeof(decoded));
         mask_decode_from_filename(decoded);
         if (strcmp(decoded, specifiers[i]) != 0) {

--- a/test_misc.c
+++ b/test_misc.c
@@ -49,6 +49,12 @@ static int group_b(void)
     str_to_lowercase(buf);
     if (strcmp(buf, "already") != 0) { fprintf(stderr, "STL-03 failed: got \"%s\"\n", buf); ok = 0; }
 
+    /* STL-04: empty string - strlen("") == 0 so loop never executes; safe.
+     * Note: str_to_lowercase has no NULL guard; passing NULL would crash. */
+    strncpy(buf, "", sizeof(buf));
+    str_to_lowercase(buf);
+    if (strcmp(buf, "") != 0) { fprintf(stderr, "STL-04 failed: got \"%s\"\n", buf); ok = 0; }
+
     return ok;
 }
 
@@ -58,13 +64,16 @@ static int group_c(void)
 {
     int ok = 1;
 
-    /* is_ntlm8 */
+    /* is_ntlm8 - reduction_offset==0 is part of the fast-path check; non-zero
+     * reduction_offset means a non-zero table_index, which uses the generic path. */
     if (is_ntlm8(HASH_NTLM, CHARSET_ASCII_32_95, 8, 8, 0, 422000) != 1)
         { fprintf(stderr, "IN8-01 failed\n"); ok = 0; }
     if (is_ntlm8(HASH_NTLM, CHARSET_ASCII_32_95, 8, 8, 0, 100000) != 0)
         { fprintf(stderr, "IN8-02 failed: wrong chain_len accepted\n"); ok = 0; }
     if (is_ntlm8(HASH_NTLM, CHARSET_NUMERIC, 8, 8, 0, 422000) != 0)
         { fprintf(stderr, "IN8-03 failed: wrong charset accepted\n"); ok = 0; }
+    if (is_ntlm8(HASH_NTLM, CHARSET_ASCII_32_95, 8, 8, 65536, 422000) != 0)
+        { fprintf(stderr, "IN8-04 failed: non-zero reduction_offset accepted\n"); ok = 0; }
 
     /* is_ntlm9 */
     if (is_ntlm9(HASH_NTLM, CHARSET_ASCII_32_95, 9, 9, 0, 803000) != 1)
@@ -73,6 +82,8 @@ static int group_c(void)
         { fprintf(stderr, "IN9-02 failed: wrong plaintext_len accepted\n"); ok = 0; }
     if (is_ntlm9(HASH_LM, CHARSET_ASCII_32_95, 9, 9, 0, 803000) != 0)
         { fprintf(stderr, "IN9-03 failed: wrong hash_type accepted\n"); ok = 0; }
+    if (is_ntlm9(HASH_NTLM, CHARSET_ASCII_32_95, 9, 9, 65536, 803000) != 0)
+        { fprintf(stderr, "IN9-04 failed: non-zero reduction_offset accepted\n"); ok = 0; }
 
     return ok;
 }
@@ -87,6 +98,12 @@ static int group_d(void)
     get_rt_log_filename(result, sizeof(result), "foo.rt");
     if (strcmp(result, "foo.rt.log") != 0)
         { fprintf(stderr, "GRLF-01 failed: got \"%s\"\n", result); ok = 0; }
+
+    /* GRLF-02: path with directory separators. */
+    memset(result, 0, sizeof(result));
+    get_rt_log_filename(result, sizeof(result), "/path/to/table.rt");
+    if (strcmp(result, "/path/to/table.rt.log") != 0)
+        { fprintf(stderr, "GRLF-02 failed: got \"%s\"\n", result); ok = 0; }
 
     return ok;
 }
@@ -214,6 +231,15 @@ static int group_h(void)
     parse_rt_params(&p, fn);
     if (p.parsed)
         { fprintf(stderr, "PRP-08 failed: zero chain_len accepted\n"); ok = 0; }
+
+    /* PRP-09: plaintext_len_max == MAX_PLAINTEXT_LEN (16) - regression for
+     * bug where '<' was used instead of '<=' in parse_rt_params validation. */
+    strncpy(fn, "ntlm_ascii-32-95#16-16_0_100000x67108864_0.rt", sizeof(fn));
+    parse_rt_params(&p, fn);
+    if (!p.parsed)
+        { fprintf(stderr, "PRP-09 failed: plaintext_len_max==16 rejected\n"); ok = 0; }
+    else if (p.plaintext_len_max != 16)
+        { fprintf(stderr, "PRP-09b failed: plaintext_len_max=%u\n", p.plaintext_len_max); ok = 0; }
 
     return ok;
 }

--- a/verify.c
+++ b/verify.c
@@ -86,6 +86,7 @@ int verify_rainbowtable(uint64_t *rainbowtable, unsigned int num_chains, unsigne
 */
       if (end < last_end) {
 	fprintf(stderr, "Error: table end indices are not sorted.  Current end index (at chain #%u) is not greater or equal to last end index.\n\n\tCurrent end index: %"PRIu64"\n\tLast end index:    %"PRIu64"\n\n", i, end, last_end);
+	*error_chain_num = i;
 	return 0;
       }
 


### PR DESCRIPTION
## Summary

- **Bug fixes**: #23 verify.c lookup path sets `*error_chain_num` on unsorted end; #36 Metal CLCREATEQUEUE suppresses `-Wunused-variable` for `err` via comma operator
- **Test improvements**: #24 move `index_ptr` allocation before `CLCREATEQUEUE`; #25 `chain_len=1` degenerate chain test; #27 high start-index (pspace_total-1) chain test; #28 large `pos` vectors (65535, 802999); #33 VR-07 `error_chain` assertion + VR-11/VR-12 edge cases; #34 direct `%` encoding assertion in Group G; #37 binary DES key test vector; #38 parameterized charset in chain tests + digits-only 3-char tests
- **Docs**: #26 pspace invariant in `cpu_rt_functions.c`; #29 `hash_validate.h` already included (pre-fixed); #30 `mask_keyspace` length precondition; #31 PRP-09 `plaintext_len_max==16` regression; #32 STL-04 empty-string test; #35 IN8-04/IN9-04 non-zero reduction_offset tests; #39 `TABLE_INDEX_TO_REDUCTION_OFFSET` overflow comment; #40 GRLF-02 directory-path test

## Test plan

- [x] `make clean && make macos` - zero warnings
- [x] `./crackalack_unit_tests` - ALL UNIT TESTS PASS

Closes #23, #24, #25, #26, #27, #28, #29, #30, #31, #32, #33, #34, #35, #36, #37, #38, #39, #40