### PR TITLE
feat(lookup): read RAR-wrapped tables (.rt.rar/.rtc.rar) via in-memory unrar

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,9 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install dependencies
-        run: sudo apt-get update && sudo apt-get install -y build-essential libgcrypt20-dev opencl-headers
+        # libunrar-dev provides -lunrar for the RAR-wrapped table ingest path
+        # (make linux links it via -DHAVE_UNRAR).  See README "OpenCL" section.
+        run: sudo apt-get update && sudo apt-get install -y build-essential libgcrypt20-dev opencl-headers libunrar-dev
 
       - name: Build (make linux)
         # Compile-only smoke: CI runners have no GPU, so we cannot execute the

--- a/Makefile
+++ b/Makefile
@@ -35,10 +35,10 @@ ifeq ($(BUILD),cuda)
   CC := $(CC_linux)
   EXE :=
   CUDA_PATH ?= /usr/local/cuda
-  CPPFLAGS := $(CPPFLAGS_common) -DUSE_CUDA -I$(CUDA_PATH)/include
+  CPPFLAGS := $(CPPFLAGS_common) -DUSE_CUDA -DHAVE_UNRAR -I$(CUDA_PATH)/include
   CFLAGS   := $(CFLAGS_common) -march=native -flto=auto
   LDFLAGS  := $(LDFLAGS_common) -flto=auto -L$(CUDA_PATH)/lib64 -Wl,-rpath,$(CUDA_PATH)/lib64
-  LIBS     := -lpthread -ldl -lgcrypt -lcuda -lnvrtc -lm
+  LIBS     := -lpthread -ldl -lgcrypt -lcuda -lnvrtc -lunrar -lm
   GPU_BACKEND_OBJ := $(OBJDIR)/cuda_setup.o
 endif
 
@@ -59,10 +59,10 @@ ifeq ($(BUILD),linux)
   # For NVIDIA-specific CUDA acceleration, use `make cuda` instead.
   CC := $(CC_linux)
   EXE :=
-  CPPFLAGS := $(CPPFLAGS_common)
+  CPPFLAGS := $(CPPFLAGS_common) -DHAVE_UNRAR
   CFLAGS   := $(CFLAGS_common) -march=native -flto=auto
   LDFLAGS  := $(LDFLAGS_common) -flto=auto
-  LIBS     := -lpthread -ldl -lgcrypt -lm
+  LIBS     := -lpthread -ldl -lgcrypt -lunrar -lm
   GPU_BACKEND_OBJ := $(OBJDIR)/opencl_setup.o
 endif
 
@@ -421,6 +421,7 @@ $(OUTDIR)/$(LOOKUP_PROG): \
 	$(OBJDIR)/misc.o \
 	$(OBJDIR)/precompute_collate.o \
 	$(GPU_BACKEND_OBJ) \
+	$(OBJDIR)/rar_decompress.o \
 	$(OBJDIR)/rtc_decompress.o \
 	$(OBJDIR)/rti2_decompress.o \
 	$(OBJDIR)/test_shared.o \

--- a/README.md
+++ b/README.md
@@ -264,16 +264,18 @@ Two GPU backends are supported on Linux: **OpenCL** (default, portable) and **CU
 
 Works with any OpenCL ICD (NVIDIA, AMD, Intel, PoCL, etc.):
 
-    # apt install opencl-headers libgcrypt20-dev
+    # apt install opencl-headers libgcrypt20-dev libunrar-dev
     $ make clean; make linux
 
 Binaries are written to the project root. `opencl_setup.c` `dlopen()`s `libOpenCL` at runtime, so no OpenCL library is needed at link time.
+
+`libunrar-dev` enables `crackalack_lookup` to read RAR-wrapped tables (`.rt.rar` / `.rtc.rar`, e.g. the infocon mirror) by decompressing them in memory. It is a Linux-only dependency; the macOS (Metal) and Windows builds omit RAR support.
 
 ### CUDA (NVIDIA only)
 
 Kernels are JIT-compiled at runtime via NVRTC. Requires the NVIDIA driver and CUDA toolkit:
 
-    # apt install nvidia-cuda-toolkit libgcrypt20-dev
+    # apt install nvidia-cuda-toolkit libgcrypt20-dev libunrar-dev
     $ make clean; make cuda
 
 Binaries are written to the project root (same location as the OpenCL build), so `make clean` is required when switching between backends.

--- a/crackalack_lookup.c
+++ b/crackalack_lookup.c
@@ -57,6 +57,9 @@
 #include "misc.h"
 #include "fa_batch.h"
 #include "precompute_collate.h"
+#ifdef HAVE_UNRAR
+#include "rar_decompress.h"
+#endif
 #include "rtc_decompress.h"
 #include "rti2_decompress.h"
 #include "ppi.h"
@@ -758,7 +761,7 @@ unsigned int count_tables(char *dir) {
     is_dir = (de->d_type == DT_DIR);
 #endif
 
-    if (is_file && (str_ends_with(de->d_name, ".rt") || str_ends_with(de->d_name, ".rtc")))
+    if (is_file && (str_ends_with(de->d_name, ".rt") || str_ends_with(de->d_name, ".rtc") || str_ends_with(de->d_name, ".rti2") || str_ends_with(de->d_name, ".rt.rar") || str_ends_with(de->d_name, ".rtc.rar")))
       ret++;
     else if (is_dir && (strcmp(de->d_name, ".") != 0) && (strcmp(de->d_name, "..") != 0)) {
       char subdir_path[1024] = {0};
@@ -793,6 +796,18 @@ void free_loaded_hashes(char **usernames, char **hashes) {
 }
 
 
+/* Copy `src` into `dst`, stripping a trailing ".rar" if present, so the inner
+ * table name (e.g. foo.rtc.rar -> foo.rtc) can be parsed and dispatched on.
+ * RAR-wrapped tables (from the infocon mirror) carry a ".rt.rar" / ".rtc.rar"
+ * suffix; the parameters live in the inner name. */
+static void strip_rar_suffix(char *dst, size_t dst_size, const char *src) {
+  strncpy(dst, src, dst_size - 1);
+  dst[dst_size - 1] = '\0';
+  if (str_ends_with(dst, ".rar"))
+    dst[strlen(dst) - 4] = '\0';
+}
+
+
 /* Recursively searches the target directory for the first rainbow table file, and uses its filename to infer
  * the rainbow table parameters. */
 void find_rt_params(char *dir_name, rt_parameters *rt_params) {
@@ -823,12 +838,15 @@ void find_rt_params(char *dir_name, rt_parameters *rt_params) {
       }
 
     /* If this is a compressed or uncompressed rainbow table, process it! */
-    } else if (str_ends_with(de->d_name, ".rt") || str_ends_with(de->d_name, ".rtc") || str_ends_with(de->d_name, ".rti2")) {
+    } else if (str_ends_with(de->d_name, ".rt") || str_ends_with(de->d_name, ".rtc") || str_ends_with(de->d_name, ".rti2") || str_ends_with(de->d_name, ".rt.rar") || str_ends_with(de->d_name, ".rtc.rar")) {
 
       /* Try to parse them from this file name.  On success, return immediately
        * (no further processing needed), otherwise continue searching until the
-       * first valid set of parameters is found. */
-      parse_rt_params(rt_params, filepath);
+       * first valid set of parameters is found.  RAR-wrapped tables carry the
+       * params in the inner name, so strip a trailing ".rar" before parsing. */
+      char parse_path[512] = {0};
+      strip_rar_suffix(parse_path, sizeof(parse_path), filepath);
+      parse_rt_params(rt_params, parse_path);
       if (rt_params->parsed) {
 	closedir(dir); dir = NULL;
 	return;
@@ -876,9 +894,11 @@ static void collect_config_groups_dir(char *dir_name, config_group **head) {
         && (stat(filepath, &st) == 0) && S_ISDIR(st.st_mode)) {
       collect_config_groups_dir(filepath, head);
 
-    } else if (str_ends_with(de->d_name, ".rt") || str_ends_with(de->d_name, ".rtc") || str_ends_with(de->d_name, ".rti2")) {
+    } else if (str_ends_with(de->d_name, ".rt") || str_ends_with(de->d_name, ".rtc") || str_ends_with(de->d_name, ".rti2") || str_ends_with(de->d_name, ".rt.rar") || str_ends_with(de->d_name, ".rtc.rar")) {
       rt_parameters p = {0};
-      parse_rt_params(&p, filepath);
+      char parse_path[512] = {0};
+      strip_rar_suffix(parse_path, sizeof(parse_path), filepath);
+      parse_rt_params(&p, parse_path);
       if (!p.parsed)
         continue;
 
@@ -931,9 +951,11 @@ unsigned int count_tables_for_config(char *dir, const rt_parameters *filter) {
     if ((strcmp(de->d_name, ".") != 0) && (strcmp(de->d_name, "..") != 0)
         && (stat(filepath, &st) == 0) && S_ISDIR(st.st_mode)) {
       count += count_tables_for_config(filepath, filter);
-    } else if (str_ends_with(de->d_name, ".rt") || str_ends_with(de->d_name, ".rtc") || str_ends_with(de->d_name, ".rti2")) {
+    } else if (str_ends_with(de->d_name, ".rt") || str_ends_with(de->d_name, ".rtc") || str_ends_with(de->d_name, ".rti2") || str_ends_with(de->d_name, ".rt.rar") || str_ends_with(de->d_name, ".rtc.rar")) {
       rt_parameters p = {0};
-      parse_rt_params(&p, filepath);
+      char parse_path[512] = {0};
+      strip_rar_suffix(parse_path, sizeof(parse_path), filepath);
+      parse_rt_params(&p, parse_path);
       if (p.parsed && configs_match(&p, filter))
         count++;
     }
@@ -2539,12 +2561,15 @@ static char **collect_table_paths(char *rt_dir, const rt_parameters *filter,
     }
 
     if (!str_ends_with(de->d_name, ".rt") && !str_ends_with(de->d_name, ".rtc") &&
-        !str_ends_with(de->d_name, ".rti2"))
+        !str_ends_with(de->d_name, ".rti2") &&
+        !str_ends_with(de->d_name, ".rt.rar") && !str_ends_with(de->d_name, ".rtc.rar"))
       continue;
 
     if (filter != NULL) {
       rt_parameters pt_params = {0};
-      parse_rt_params(&pt_params, filepath);
+      char parse_path[512] = {0};
+      strip_rar_suffix(parse_path, sizeof(parse_path), filepath);
+      parse_rt_params(&pt_params, parse_path);
       if (!pt_params.parsed || !configs_match(&pt_params, filter))
         continue;
     }
@@ -2562,6 +2587,16 @@ static int load_single_table(const char *filepath, preloaded_table *pt) {
   gpu_ulong *rainbow_table = NULL;
   uint64_t num_chains = 0;
 
+#ifdef HAVE_UNRAR
+  if (str_ends_with(filepath, ".rt.rar") || str_ends_with(filepath, ".rtc.rar")) {
+    /* RAR-wrapped table (infocon mirror): the archive holds a single raw .rt
+     * table, so rar_decompress() yields the final start/end longs directly. */
+    unsigned int rar_num_chains = 0;
+    if (rar_decompress((char *)filepath, (uint64_t **)&rainbow_table, &rar_num_chains) != 0)
+      return -1;
+    num_chains = rar_num_chains;
+  } else
+#endif
   if (str_ends_with(filepath, ".rtc")) {
     if (rtc_decompress((char *)filepath, &rainbow_table, &num_chains) != 0)
       return -1;

--- a/rar_decompress.c
+++ b/rar_decompress.c
@@ -1,0 +1,117 @@
+/* RAR-wrapped rainbow table support depends on libunrar, which is only wired up
+ * on the Linux OpenCL/CUDA builds (-DHAVE_UNRAR).  On macOS/Windows this file
+ * compiles to an empty object so the shared source wildcard keeps working. */
+#ifdef HAVE_UNRAR
+
+#define _UNIX
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <inttypes.h>
+#include <unrar/dll.hpp>
+
+#include "rar_decompress.h"
+
+#define RAR_INITIAL_CAPACITY (64 * 1024 * 1024)
+
+typedef struct {
+  unsigned char *buf;
+  size_t size;
+  size_t capacity;
+} membuf;
+
+
+static int CALLBACK rar_data_callback(UINT msg, LPARAM user_data, LPARAM p1, LPARAM p2) {
+  if (msg == UCM_PROCESSDATA) {
+    membuf *mb = (membuf *)user_data;
+    size_t needed = mb->size + p2;
+
+    if (needed > mb->capacity) {
+      size_t new_cap = mb->capacity * 2;
+      if (new_cap < needed)
+        new_cap = needed;
+      unsigned char *tmp = (unsigned char *)realloc(mb->buf, new_cap);
+      if (!tmp)
+        return -1;
+      mb->buf = tmp;
+      mb->capacity = new_cap;
+    }
+
+    memcpy(mb->buf + mb->size, (void *)p1, p2);
+    mb->size += p2;
+    return 1;
+  }
+  return 0;
+}
+
+
+/* Decompresses a RAR archive containing a single rainbow table file into memory.
+ * Returns 0 on success, or a negative error code. */
+int rar_decompress(char *filename, uint64_t **ret_uncompressed_table, unsigned int *ret_num_chains) {
+  struct RAROpenArchiveDataEx arc_data;
+  struct RARHeaderDataEx hdr;
+  HANDLE h = NULL;
+  membuf mb = {0, 0, 0};
+  int ret = 0, r = 0;
+
+  *ret_uncompressed_table = NULL;
+  *ret_num_chains = 0;
+
+  memset(&arc_data, 0, sizeof(arc_data));
+  arc_data.ArcName = filename;
+  arc_data.OpenMode = RAR_OM_EXTRACT;
+
+  h = RAROpenArchiveEx(&arc_data);
+  if (!h || arc_data.OpenResult != ERAR_SUCCESS) {
+    fprintf(stderr, "Error: failed to open RAR archive %s: error %u\n", filename, arc_data.OpenResult);
+    ret = -1;
+    goto done;
+  }
+
+  mb.capacity = RAR_INITIAL_CAPACITY;
+  mb.buf = (unsigned char *)malloc(mb.capacity);
+  if (!mb.buf) {
+    fprintf(stderr, "Error: could not allocate initial buffer for RAR decompression.\n");
+    ret = -2;
+    goto done;
+  }
+
+  RARSetCallback(h, rar_data_callback, (LPARAM)&mb);
+
+  memset(&hdr, 0, sizeof(hdr));
+  r = RARReadHeaderEx(h, &hdr);
+  if (r != ERAR_SUCCESS) {
+    fprintf(stderr, "Error: failed to read RAR header from %s: error %d\n", filename, r);
+    ret = -3;
+    goto done;
+  }
+
+  r = RARProcessFile(h, RAR_TEST, NULL, NULL);
+  if (r != ERAR_SUCCESS) {
+    fprintf(stderr, "Error: failed to decompress RAR file %s: error %d\n", filename, r);
+    ret = -4;
+    goto done;
+  }
+
+  if (mb.size == 0 || mb.size % (sizeof(uint64_t) * 2) != 0) {
+    fprintf(stderr, "Error: decompressed RAR data size (%zu) is not a valid rainbow table (must be a multiple of %zu).\n", mb.size, sizeof(uint64_t) * 2);
+    ret = -5;
+    goto done;
+  }
+
+  *ret_uncompressed_table = (uint64_t *)mb.buf;
+  *ret_num_chains = mb.size / (sizeof(uint64_t) * 2);
+  mb.buf = NULL;
+
+done:
+  if (h)
+    RARCloseArchive(h);
+
+  if (mb.buf)
+    free(mb.buf);
+
+  return ret;
+}
+
+#endif /* HAVE_UNRAR */

--- a/rar_decompress.h
+++ b/rar_decompress.h
@@ -1,0 +1,8 @@
+#ifndef _RAR_DECOMPRESS_H
+#define _RAR_DECOMPRESS_H
+
+#include <stdint.h>
+
+int rar_decompress(char *filename, uint64_t **uncompressed_table, unsigned int *num_chains);
+
+#endif


### PR DESCRIPTION
## What

Adds support for reading RAR-wrapped rainbow tables (`.rt.rar` / `.rtc.rar`) directly in `crackalack_lookup`, decompressing them in memory — no manual unrar step. This lets the tool ingest the infocon-mirror table set as-is.

Ports blurbdust's `rar_decompress.c` / `.h` (upstream commit `02ccfb7`) and wires it into this fork's split load architecture.

## How

- `rar_decompress()` extracts a single raw `.rt` table from the archive and returns the start/end longs (verified byte-identical to the unwrapped `.rt`).
- Wired into `load_single_table()` (this fork separates path collection from loading, unlike upstream's inline `_preloading_thread`).
- Every table scan/count/param-parse site recognizes the new suffixes: `count_tables`, `find_rt_params`, `collect_config_groups_dir`, `count_tables_for_config`, `collect_table_paths`.
- A `strip_rar_suffix()` helper feeds the inner name to `parse_rt_params`, so filenames stay self-describing.

## Cross-platform

`libunrar` is Linux-only, so the whole feature is gated behind `-DHAVE_UNRAR` (set for the `linux`/OpenCL and `cuda` builds, which also add `-lunrar`). On macOS/Windows, `rar_decompress.c` compiles to an empty object and the RAR branch is `#ifdef`'d out — those builds stay link-clean.

## Verification (dell3)

- `make linux` (OpenCL) and `make cuda` (NVIDIA) both build and link `crackalack_lookup` against `libunrar`.
- `make macos` (Metal) links with no unrar dependency.
- Byte-identity: `unrar` of a `.rt.rar` is `cmp`-identical to the source `.rt`.
- Functional differential (`.rt` vs `.rt.rar`, single config group): both exit 0, no load errors, **identical 32892 potential matches**, output identical except timing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)