### PR TITLE
fix(lookup): free charset_len_buffer (GPU buffer leak aborting multi-config-group lookups)

### DIFF
--- a/crackalack_lookup.c
+++ b/crackalack_lookup.c
@@ -1437,6 +1437,7 @@ void *host_thread_false_alarm(void *ptr) {
 
   CLFREEBUFFER(hash_type_buffer);
   CLFREEBUFFER(charset_buffer);
+  CLFREEBUFFER(charset_len_buffer);  /* Was leaked: created above but never freed, so one GPU buffer accumulated per config group until clCreateContext hit CL_OUT_OF_HOST_MEMORY. */
   CLFREEBUFFER(plaintext_len_min_buffer);
   CLFREEBUFFER(plaintext_len_max_buffer);
   CLFREEBUFFER(reduction_offset_buffer);
@@ -1808,6 +1809,7 @@ void *host_thread_precompute(void *ptr) {
   CLFREEBUFFER(hash_buffer);
   CLFREEBUFFER(hash_len_buffer);
   CLFREEBUFFER(charset_buffer);
+  CLFREEBUFFER(charset_len_buffer);  /* Was leaked: created above but never freed (same bug as the false-alarm path). */
   CLFREEBUFFER(plaintext_len_min_buffer);
   CLFREEBUFFER(plaintext_len_max_buffer);
   CLFREEBUFFER(table_index_buffer);


### PR DESCRIPTION
## Symptom

Multi-config-group lookups abort partway through with `Failed to create context: -6` (`CL_OUT_OF_HOST_MEMORY`) — observed at config group ~7 of a full-size table campaign.

## Root cause

`charset_len_buffer` is created in both `host_thread_false_alarm()` and `host_thread_precompute()` but freed in **neither** — only the batch-precompute path (`batch_precompute_all_hashes`) released it. Every GPU false-alarm / per-hash-precompute invocation leaked one GPU memory buffer. Across config groups these accumulate on the device until `clCreateContext()` can no longer allocate.

## Evidence

Wrapped the OpenCL create/release entry points with live counters and dumped them per config group:

```
group-1-start  ctx=0 buf=0  ...
group-2-start  ctx=0 buf=6      <- +6 buffers, contexts/queues/programs/kernels all balanced
group-3-start  ctx=0 buf=12
...
group-10-start ctx=0 buf=54
```

Only `buf` climbed (monotonic, ~one per GPU false-alarm invocation). After adding the frees, `buf` stays flat at 0 across all 10 groups and the full run completes (`exit=0`, 0 context errors, potential-match counts unchanged).

## Fix

Add the missing `CLFREEBUFFER(charset_len_buffer)` to both cleanup paths. Shared host code, so this affected all backends (OpenCL/CUDA/Metal).

## Verification

- `make linux`, `make cuda`, `make macos` all build.
- dell3 OpenCL run: buffer counter flat across 10 config groups (was +N/group); full lookup completes cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)