### PR TITLE
fix(gen): stop resumed tables from overwriting themselves from byte 0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -181,6 +181,8 @@ CPU_TESTS_OBJS := \
 	$(CPU_TESTS_OBJDIR)/hcmask.o \
 	$(CPU_TESTS_OBJDIR)/test_golden.o \
 	$(CPU_TESTS_OBJDIR)/test_shared.o \
+	$(CPU_TESTS_OBJDIR)/test_chain_writer.o \
+	$(CPU_TESTS_OBJDIR)/chain_writer.o \
 	$(CPU_TESTS_OBJDIR)/misc.o \
 	$(CPU_TESTS_OBJDIR)/fa_batch.o \
 	$(CPU_TESTS_OBJDIR)/bloom.o \
@@ -301,6 +303,7 @@ $(OBJDIR)/%.o: %.m | $(OBJDIR)
 -include $(DEPS)
 
 $(OUTDIR)/$(GEN_PROG): \
+	$(OBJDIR)/chain_writer.o \
 	$(OBJDIR)/charset.o \
 	$(OBJDIR)/checkpoint.o \
 	$(OBJDIR)/clock.o \
@@ -321,6 +324,8 @@ $(OUTDIR)/$(GEN_PROG): \
 
 $(OUTDIR)/$(UNITTEST_PROG): \
 	$(OBJDIR)/bloom.o \
+	$(OBJDIR)/chain_writer.o \
+	$(OBJDIR)/test_chain_writer.o \
 	$(OBJDIR)/charset.o \
 	$(OBJDIR)/cpu_rt_functions.o \
 	$(OBJDIR)/cpu_tests_common.o \

--- a/README.md
+++ b/README.md
@@ -330,6 +330,9 @@ Two instrumentation entry points remain in-tree via the Makefile:
 |`make COVERAGE=1 <target>`   |gcov/llvm-cov line-coverage build for the host code.     |
 
 ## Change Log
+### v1.5.4
+ - Fixed a data-destroying bug in `crackalack_gen` when resuming a partially generated table. `write_chains()` derived each chain's file offset from `first_generated_chain`, which holds `total_chains_in_table * part_index` on a fresh run (correct: that is the chain stored at file offset 0) but is reassigned to the resume point when an unfinished table is picked back up. The first chain written after a resume therefore landed at offset 0 and overwrote the table from the beginning, while the file size stayed frozen at its pre-resume value. Both the checkpoint resume path and the legacy (no `.state`) resume path were affected, on every backend. The chain index stored at file offset 0 is now tracked separately in `file_base_chain`, set once from the part index and never adjusted by resume logic. `write_chains()` moved to `chain_writer.c` so it can be linked into the test binaries, and `tests/test_chain_writer.c` covers both resume-append and non-zero part index in the CPU-only suite.
+
 ### v1.5.3
  - `crackalack_verify` now accepts `--markov-keyspace N` and reports the Markov keyspace encoded in the table filename (the `-mk<N>` tag). The value is parsed from the filename only — table contents are not scanned to derive it. If `--markov-keyspace` is supplied, verify warns when it disagrees with the filename (the filename value is authoritative) or when the filename carries no keyspace tag.
 

--- a/chain_writer.c
+++ b/chain_writer.c
@@ -1,0 +1,132 @@
+/*
+ * Rainbow Crackalack: chain_writer.c
+ * Copyright (C) 2018-2020  Joe Testa <jtesta@positronsecurity.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms version 3 of the GNU General Public License as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifdef _WIN32
+#include <windows.h>
+#endif
+
+#include <inttypes.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#include "chain_writer.h"
+#include "file_lock.h"
+#include "misc.h"
+#include "shared.h"
+
+
+/* See chain_writer.h for the distinction between these two. */
+uint64_t first_generated_chain = 0;
+uint64_t file_base_chain = 0;
+
+
+/* Writes the chains given by the kernel to the file. */
+void write_chains(char *filename, unsigned int chains_per_work_unit, uint64_t *start_indices, unsigned int start_indices_size, uint64_t *end_indices, unsigned int end_indices_size, unsigned int thread_id) {
+  int i = 0, j = 0;
+  uint64_t file_size = 0;
+  uint64_t start = 0;
+  rc_file f = rc_fopen(filename, 0), l = NULL;
+  char log_filename[256] = {0};
+  int empty_chains = 0;
+
+
+  if (f == NULL)
+    exit(-1);
+
+  /* Get an exclusive lock on all bytes of the file, including those not yet written
+   * (i.e.: another thread cannot write past the current end of the file).  */
+  if (rc_flock(f) != 0)
+    exit(-1);
+
+  /* Get the filename of the rainbow table log to write to, then open it for appending.
+   *  This is the same filename as the rainbow table, but with ".log" appended. */
+  get_rt_log_filename(log_filename, sizeof(log_filename), filename);
+  l = rc_fopen(log_filename, 1);
+  if (l == NULL)
+    exit(-1);
+
+  /* Get a lock on the log.  Probably not strictly necessary, since the table is locked
+   * first, and other threads are blocked at this point... */
+  if (rc_flock(l) != 0)
+    fprintf(stderr, "\nError while locking log file!\n");
+
+  /* Go to the end of the table file. */
+  if (rc_fseek(f, 0, RCSEEK_END) != 0) {
+    fprintf(stderr, "Error seeking to end of output file.\n");
+    exit(-1);
+  }
+
+  /* If we have results that extend past the end of the file, write zeros as
+   * placeholders until we get to the point where our data starts. */
+  file_size = rc_ftell(f);
+
+  rt_log(l, "Thread #%u: file size at start is %"PRIu64" (%"PRIu64" chains)\n", thread_id, file_size, file_size / CHAIN_SIZE);
+
+  empty_chains = (int)((((start_indices[0] - file_base_chain) * CHAIN_SIZE) - file_size) / CHAIN_SIZE);
+
+  if (empty_chains > 0)
+    rt_log(l, "\tWriting %d empty chains (%u bytes)\n", empty_chains, empty_chains * CHAIN_SIZE);
+
+  for (i = 0; i < empty_chains; i++) {
+    rc_fwrite(&start, sizeof(start), 1, f);
+    rc_fwrite(&start, sizeof(start), 1, f);
+  }
+
+  /* Otherwise, if another thread wrote placeholders already, seek to the point at which
+   * we need to overwrite. */
+  rt_log(l, "\tSeeking to position %lu (chain #%lu).\n", (start_indices[0] - file_base_chain) * CHAIN_SIZE, start_indices[0] - file_base_chain);
+  if (rc_fseek(f, (start_indices[0] - file_base_chain) * CHAIN_SIZE, RCSEEK_SET) != 0) {
+    perror("Error seeking in file");
+    exit(-1);
+  }
+
+  /* Write the chains. */
+  for (i = 0; i < start_indices_size; i++) {
+    start = start_indices[i];
+    for (j = (i * chains_per_work_unit); (j < ((i * chains_per_work_unit) + chains_per_work_unit)) && (j < end_indices_size); j++) {
+      rc_fwrite(&start, sizeof(uint64_t), 1, f);
+      rc_fwrite(&(end_indices[j]), sizeof(uint64_t), 1, f);
+      start++;
+    }
+  }
+
+  if (start_indices_size > 0)
+    rt_log(l, "\tWrote chains start indices from %"PRIu64" to %"PRIu64"\n", start_indices[0], start - 1);
+
+  /* Sync to disk to ensure data durability */
+#ifdef _WIN32
+  FlushFileBuffers(f);
+#else
+  fflush(f);
+  fsync(fileno(f));
+#endif
+
+  /* Verify write succeeded by checking file size */
+  rc_fseek(f, 0, RCSEEK_END);
+  uint64_t actual_size = rc_ftell(f);
+  uint64_t expected_size = (start_indices[start_indices_size - 1] - file_base_chain + 1) * CHAIN_SIZE;
+  if (actual_size < expected_size) {
+    fprintf(stderr, "\nWarning: file size mismatch after write. Expected at least %"PRIu64", got %"PRIu64"\n",
+            expected_size, actual_size);
+    rt_log(l, "\tERROR: File size mismatch. Expected %"PRIu64", got %"PRIu64"\n",
+           expected_size, actual_size);
+  }
+
+  rc_fclose(l);
+  rc_fclose(f);
+}

--- a/chain_writer.h
+++ b/chain_writer.h
@@ -1,0 +1,35 @@
+/*
+ * Rainbow Crackalack: chain_writer.h
+ * Copyright (C) 2018-2020  Joe Testa <jtesta@positronsecurity.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms version 3 of the GNU General Public License as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef _CHAIN_WRITER_H
+#define _CHAIN_WRITER_H
+
+#include <stdint.h>
+
+/* The first chain that this run will generate.  Not zero when resuming an
+ * unfinished file, or when the part index is greater than zero. */
+extern uint64_t first_generated_chain;
+
+/* The chain index stored at file offset 0.  For part index N this is
+ * (total_chains_in_table * N).  Resuming an unfinished table does not move the
+ * start of the file, so this must NOT be set to the resume point. */
+extern uint64_t file_base_chain;
+
+/* Writes the chains given by the kernel to the file. */
+void write_chains(char *filename, unsigned int chains_per_work_unit, uint64_t *start_indices, unsigned int start_indices_size, uint64_t *end_indices, unsigned int end_indices_size, unsigned int thread_id);
+
+#endif

--- a/crackalack_gen.c
+++ b/crackalack_gen.c
@@ -36,6 +36,7 @@
 
 #include "gpu_backend.h"
 
+#include "chain_writer.h"
 #include "charset.h"
 #include "checkpoint.h"
 #include "markov.h"
@@ -87,8 +88,6 @@
   if (pthread_mutex_unlock(&start_index_mutex)) { perror("Failed to unlock mutex"); exit(-1); }
 
 #define ROUND(_x) ((unsigned int)(_x + 0.5))
-
-void write_chains(char *filename, unsigned int chains_per_work_unit, gpu_ulong *start_indices, unsigned int start_indices_size, gpu_ulong *end_indices, unsigned int end_indices_size, unsigned int thread_id);
 
 
 struct hash_names {
@@ -189,10 +188,7 @@ uint64_t start_index = 0;
  * partially-constructed table. */
 uint64_t num_chains_to_generate = 0;
 
-/* The first chain that we will generate (this will not be zero if we resume an
- * unfinished file or part index > 0).  We use this to track how many chains we
- * generated so far. */
-uint64_t first_generated_chain = 0;
+/* first_generated_chain and file_base_chain are defined in chain_writer.c. */
 
 /* The time that the threads were started. */
 struct timespec global_start_time = {0};
@@ -863,103 +859,6 @@ void *host_thread(void *ptr) {
 }
 
 
-/* Writes the chains given by the kernel to the file. */
-void write_chains(char *filename, unsigned int chains_per_work_unit, gpu_ulong *start_indices, unsigned int start_indices_size, gpu_ulong *end_indices, unsigned int end_indices_size, unsigned int thread_id) {
-  int i = 0, j = 0;
-  uint64_t file_size = 0;
-  gpu_ulong start = 0;
-  rc_file f = rc_fopen(filename, 0), l = NULL;
-  char log_filename[256] = {0};
-  int empty_chains = 0;
-
-
-  if (f == NULL)
-    exit(-1);
-
-  /* Get an exclusive lock on all bytes of the file, including those not yet written
-   * (i.e.: another thread cannot write past the current end of the file).  */
-  if (rc_flock(f) != 0)
-    exit(-1);
-
-  /* Get the filename of the rainbow table log to write to, then open it for appending.
-   *  This is the same filename as the rainbow table, but with ".log" appended. */
-  get_rt_log_filename(log_filename, sizeof(log_filename), filename);
-  l = rc_fopen(log_filename, 1);
-  if (l == NULL)
-    exit(-1);
-
-  /* Get a lock on the log.  Probably not strictly necessary, since the table is locked
-   * first, and other threads are blocked at this point... */
-  if (rc_flock(l) != 0)
-    fprintf(stderr, "\nError while locking log file!\n");
-
-  /* Go to the end of the table file. */
-  if (rc_fseek(f, 0, RCSEEK_END) != 0) {
-    fprintf(stderr, "Error seeking to end of output file.\n");
-    exit(-1);
-  }
-
-  /* If we have results that extend past the end of the file, write zeros as
-   * placeholders until we get to the point where our data starts. */
-  file_size = rc_ftell(f);
-
-  rt_log(l, "Thread #%u: file size at start is %"PRIu64" (%"PRIu64" chains)\n", thread_id, file_size, file_size / CHAIN_SIZE);
-
-  empty_chains = (int)((((start_indices[0] - first_generated_chain) * CHAIN_SIZE) - file_size) / CHAIN_SIZE);
-
-  if (empty_chains > 0)
-    rt_log(l, "\tWriting %d empty chains (%u bytes)\n", empty_chains, empty_chains * CHAIN_SIZE);
-
-  for (i = 0; i < empty_chains; i++) {
-    rc_fwrite(&start, sizeof(start), 1, f);
-    rc_fwrite(&start, sizeof(start), 1, f);
-  }
-
-  /* Otherwise, if another thread wrote placeholders already, seek to the point at which
-   * we need to overwrite. */
-  rt_log(l, "\tSeeking to position %lu (chain #%lu).\n", (start_indices[0] - first_generated_chain) * CHAIN_SIZE, start_indices[0] - first_generated_chain);
-  if (rc_fseek(f, (start_indices[0] - first_generated_chain) * CHAIN_SIZE, RCSEEK_SET) != 0) {
-    perror("Error seeking in file");
-    exit(-1);
-  }
-
-  /* Write the chains. */
-  for (i = 0; i < start_indices_size; i++) {
-    start = start_indices[i];
-    for (j = (i * chains_per_work_unit); (j < ((i * chains_per_work_unit) + chains_per_work_unit)) && (j < end_indices_size); j++) {
-      rc_fwrite(&start, sizeof(gpu_ulong), 1, f);
-      rc_fwrite(&(end_indices[j]), sizeof(gpu_ulong), 1, f);
-      start++;
-    }
-  }
-
-  if (start_indices_size > 0)
-    rt_log(l, "\tWrote chains start indices from %"PRIu64" to %"PRIu64"\n", start_indices[0], start - 1);
-
-  /* Sync to disk to ensure data durability */
-#ifdef _WIN32
-  FlushFileBuffers(f);
-#else
-  fflush(f);
-  fsync(fileno(f));
-#endif
-
-  /* Verify write succeeded by checking file size */
-  rc_fseek(f, 0, RCSEEK_END);
-  uint64_t actual_size = rc_ftell(f);
-  uint64_t expected_size = (start_indices[start_indices_size - 1] - first_generated_chain + 1) * CHAIN_SIZE;
-  if (actual_size < expected_size) {
-    fprintf(stderr, "\nWarning: file size mismatch after write. Expected at least %"PRIu64", got %"PRIu64"\n",
-            expected_size, actual_size);
-    rt_log(l, "\tERROR: File size mismatch. Expected %"PRIu64", got %"PRIu64"\n",
-           expected_size, actual_size);
-  }
-
-  rc_fclose(l);
-  rc_fclose(f);
-}
-
-
 int main(int ac, char **av) {
   gpu_platform platforms[MAX_NUM_PLATFORMS] = {0};
   gpu_device devices[MAX_NUM_DEVICES] = {0};
@@ -1323,6 +1222,11 @@ int main(int ac, char **av) {
    * rcrack/rcracki_mt, but its untested as of right now... */
   if (total_chains_in_table >= 134217728)
     printf("\nWARNING: chain counts >= 134217728 are untested.  Generated tables may not work in rcrack/rcracki_mt.  Continuing anyway...\n\n");
+
+  /* The chain at file offset 0 is determined solely by the part index.  Resuming
+   * an unfinished table moves where generation starts, but not where the file
+   * starts, so this is set before the resume logic below and never adjusted. */
+  file_base_chain = total_chains_in_table * part_index;
 
   /* Create the output file and test if it can be successfully locked. */
   f = rc_fopen(filename, 1);

--- a/tests/cpu_tests_common.c
+++ b/tests/cpu_tests_common.c
@@ -20,6 +20,7 @@
 #include "test_mask_parse.h"
 #include "test_markov_mask.h"
 #include "test_hcmask.h"
+#include "test_chain_writer.h"
 #include "test_golden.h"
 
 /* terminal_color.h defines these as globals; declare them extern here to
@@ -119,6 +120,15 @@ int run_cpu_only_tests(void) {
    * hash_to_index, and index_to_plaintext so backend drift is caught. */
   printf("Running golden vector tests... "); fflush(stdout);
   if (!test_golden()) {
+    all_passed = 0;
+    PRINT_FAILED();
+  } else
+    PRINT_PASSED();
+
+  /* Chain writer file-offset tests: a resumed table must be appended to, not
+   * overwritten from the start. */
+  printf("Running chain writer tests... "); fflush(stdout);
+  if (!test_chain_writer()) {
     all_passed = 0;
     PRINT_FAILED();
   } else

--- a/tests/test_chain_writer.c
+++ b/tests/test_chain_writer.c
@@ -1,0 +1,220 @@
+/*
+ * Rainbow Crackalack: test_chain_writer.c
+ *
+ * Tests that write_chains() places chains at the correct file offset.
+ *
+ * The offset of a chain within a table file is determined by the chain index
+ * stored at offset 0 -- which is (total_chains_in_table * part_index) -- and
+ * NOT by the first chain this particular run happens to generate.  Conflating
+ * the two silently destroys the existing contents of a table that is being
+ * resumed, because the first chain generated after the resume lands at offset
+ * zero instead of at the end of the file.
+ */
+
+#include <inttypes.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "chain_writer.h"
+#include "misc.h"
+#include "shared.h"
+#include "test_chain_writer.h"
+
+
+#define TEST_TABLE_PATH "/tmp/crackalack_test_chain_writer.rt"
+
+
+/* Reads chain number 'n' out of the table file.  Returns 0 on success. */
+static int read_chain(const char *path, uint64_t n, uint64_t *start_out, uint64_t *end_out) {
+  FILE *f = fopen(path, "rb");
+  int ret = -1;
+
+  if (f == NULL)
+    return -1;
+
+  if (fseek(f, (long)(n * CHAIN_SIZE), SEEK_SET) == 0 &&
+      fread(start_out, sizeof(uint64_t), 1, f) == 1 &&
+      fread(end_out, sizeof(uint64_t), 1, f) == 1)
+    ret = 0;
+
+  fclose(f);
+  return ret;
+}
+
+
+static uint64_t file_size_of(const char *path) {
+  FILE *f = fopen(path, "rb");
+  long size = 0;
+
+  if (f == NULL)
+    return 0;
+
+  fseek(f, 0, SEEK_END);
+  size = ftell(f);
+  fclose(f);
+  return (uint64_t)size;
+}
+
+
+/* Writes 'n' chains to a fresh file, so we have something to resume from.  Chain
+ * i holds start index (base + i) and end index (0xe000 + i) so that clobbered
+ * data is easy to spot. */
+static int seed_table(const char *path, uint64_t base, uint64_t n) {
+  FILE *f = fopen(path, "wb");
+  uint64_t i = 0, start = 0, end = 0;
+
+  if (f == NULL)
+    return -1;
+
+  for (i = 0; i < n; i++) {
+    start = base + i;
+    end = 0xe000 + i;
+    if ((fwrite(&start, sizeof(start), 1, f) != 1) ||
+        (fwrite(&end, sizeof(end), 1, f) != 1)) {
+      fclose(f);
+      return -1;
+    }
+  }
+
+  fclose(f);
+  return 0;
+}
+
+
+static void cleanup(const char *path) {
+  char log_path[512] = {0};
+
+  unlink(path);
+  snprintf(log_path, sizeof(log_path) - 1, "%s.log", path);
+  unlink(log_path);
+}
+
+
+/* A table that is resumed must have the new chains appended, leaving the chains
+ * already in the file untouched. */
+static int test_resume_appends_without_clobbering(void) {
+  uint64_t start_indices[4] = {256, 257, 258, 259};
+  uint64_t end_indices[4] = {0xf000, 0xf001, 0xf002, 0xf003};
+  uint64_t start = 0, end = 0;
+  unsigned int i = 0;
+  int failed = 0;
+
+  cleanup(TEST_TABLE_PATH);
+
+  /* The file already holds chains 0 through 255 from an earlier run. */
+  if (seed_table(TEST_TABLE_PATH, 0, 256) != 0) {
+    fprintf(stderr, "test_chain_writer: failed to seed table\n");
+    return -1;
+  }
+
+  /* Part index 0, so the chain at file offset 0 is chain 0... */
+  file_base_chain = 0;
+
+  /* ...but this run resumes, so it starts generating at chain 256. */
+  first_generated_chain = 256;
+
+  write_chains(TEST_TABLE_PATH, 1, start_indices, 4, end_indices, 4, 0);
+
+  /* The four new chains must land at chains 256-259. */
+  for (i = 0; i < 4; i++) {
+    if (read_chain(TEST_TABLE_PATH, 256 + i, &start, &end) != 0) {
+      fprintf(stderr, "test_chain_writer: could not read chain %u\n", 256 + i);
+      failed = 1;
+      break;
+    }
+    if ((start != start_indices[i]) || (end != end_indices[i])) {
+      fprintf(stderr, "test_chain_writer: chain %u is (%"PRIu64", 0x%"PRIx64"); expected (%"PRIu64", 0x%"PRIx64")\n",
+              256 + i, start, end, start_indices[i], end_indices[i]);
+      failed = 1;
+    }
+  }
+
+  /* Every chain that was already in the file must be untouched. */
+  for (i = 0; i < 256; i++) {
+    if (read_chain(TEST_TABLE_PATH, i, &start, &end) != 0) {
+      fprintf(stderr, "test_chain_writer: could not read pre-existing chain %u\n", i);
+      failed = 1;
+      break;
+    }
+    if ((start != i) || (end != (0xe000 + i))) {
+      fprintf(stderr, "test_chain_writer: pre-existing chain %u was clobbered: got (%"PRIu64", 0x%"PRIx64"); expected (%u, 0x%x)\n",
+              i, start, end, i, 0xe000 + i);
+      failed = 1;
+      break;
+    }
+  }
+
+  if (file_size_of(TEST_TABLE_PATH) != (260 * CHAIN_SIZE)) {
+    fprintf(stderr, "test_chain_writer: table is %"PRIu64" bytes; expected %u\n",
+            file_size_of(TEST_TABLE_PATH), 260 * CHAIN_SIZE);
+    failed = 1;
+  }
+
+  cleanup(TEST_TABLE_PATH);
+  return failed ? -1 : 0;
+}
+
+
+/* Part index > 0 means chain (total_chains * part_index) sits at file offset 0,
+ * so a fresh part file must start writing at offset 0, not far past it. */
+static int test_nonzero_part_index_starts_at_offset_zero(void) {
+  uint64_t start_indices[2] = {5000, 5001};
+  uint64_t end_indices[2] = {0xabc0, 0xabc1};
+  uint64_t start = 0, end = 0;
+  int failed = 0;
+
+  cleanup(TEST_TABLE_PATH);
+
+  /* An empty part file: part 1 of a table with 5000 chains per part. */
+  if (seed_table(TEST_TABLE_PATH, 0, 0) != 0) {
+    fprintf(stderr, "test_chain_writer: failed to create empty table\n");
+    return -1;
+  }
+
+  file_base_chain = 5000;
+  first_generated_chain = 5000;
+
+  write_chains(TEST_TABLE_PATH, 1, start_indices, 2, end_indices, 2, 0);
+
+  if (read_chain(TEST_TABLE_PATH, 0, &start, &end) != 0) {
+    fprintf(stderr, "test_chain_writer: could not read chain 0 of part file\n");
+    failed = 1;
+  } else if ((start != 5000) || (end != 0xabc0)) {
+    fprintf(stderr, "test_chain_writer: part file chain 0 is (%"PRIu64", 0x%"PRIx64"); expected (5000, 0xabc0)\n", start, end);
+    failed = 1;
+  }
+
+  if (file_size_of(TEST_TABLE_PATH) != (2 * CHAIN_SIZE)) {
+    fprintf(stderr, "test_chain_writer: part file is %"PRIu64" bytes; expected %u\n",
+            file_size_of(TEST_TABLE_PATH), 2 * CHAIN_SIZE);
+    failed = 1;
+  }
+
+  cleanup(TEST_TABLE_PATH);
+  return failed ? -1 : 0;
+}
+
+
+int test_chain_writer(void) {
+  int all_passed = 1;
+
+  printf("Testing chain writer file offsets...\n"); fflush(stdout);
+
+  if (test_resume_appends_without_clobbering() != 0) {
+    fprintf(stderr, "\tresume append: FAILED\n");
+    all_passed = 0;
+  } else
+    printf("\tresume append: passed\n");
+
+  if (test_nonzero_part_index_starts_at_offset_zero() != 0) {
+    fprintf(stderr, "\tnon-zero part index: FAILED\n");
+    all_passed = 0;
+  } else
+    printf("\tnon-zero part index: passed\n");
+
+  fflush(stdout);
+  return all_passed;
+}

--- a/tests/test_chain_writer.h
+++ b/tests/test_chain_writer.h
@@ -1,0 +1,6 @@
+#ifndef _TEST_CHAIN_WRITER_H
+#define _TEST_CHAIN_WRITER_H
+
+int test_chain_writer(void);
+
+#endif

--- a/version.h
+++ b/version.h
@@ -3,7 +3,7 @@
 
 #include "terminal_color.h"
 
-#define VERSION "v1.3.1"
+#define VERSION "v1.5.4"
 
 #define PRINT_PROJECT_HEADER() printf("\n%sRainbow Crackalack %s%s\nCopyright 2018-2021 Positron Security LLC <https://www.positronsecurity.com/>\n%s%s\n\n\n", WHITEB, VERSION, CLR, ITALICIZE, CLR);
 


### PR DESCRIPTION
## Problem

`write_chains()` computed each chain's file offset relative to `first_generated_chain`. That global means two different things depending on how the run started. On a fresh run it holds `total_chains_in_table * part_index` — genuinely the chain stored at file offset 0, so the arithmetic was correct. On a resume it is reassigned to the resume point, so the first chain generated after resuming got written at offset 0 and clobbered the table from the beginning.

The signature: the log reports `Resuming from checkpoint: N chains already generated (X%)`, the chain counter climbs normally, but the `.rt` file size stays frozen at its pre-resume value while mtime advances — the writer is overwriting existing bytes instead of appending. The `.rt.log` keeps growing correctly because it is opened in append mode.

Reproduced byte-identically on an RTX 3060 Ti writing to NFS and an RTX 3080 Ti writing to local ext4, so it is not a filesystem artifact. It affects both the checkpoint resume path and the legacy (no `.state`) path on every backend. It went unnoticed because tables that run start to finish never exercise resume.

## Fix

The chain index stored at file offset 0 now lives in its own global, `file_base_chain`, set once from the part index before any resume logic runs and never adjusted afterward. All four offset computations in the writer use it. `first_generated_chain` keeps its other job of tracking how many chains this run has produced.

## Testing

`write_chains()` moves to `chain_writer.c` because `crackalack_gen.c` defines `main()`, so nothing could link against it to test it. The new `tests/test_chain_writer.c` covers a resumed table (new chains appended, prior chains intact, file grows) and a non-zero part index (must still write at offset 0), and runs in both the CPU-only and GPU suites. Against the unfixed writer the resume case fails with exactly the production symptom: chain 0 clobbered and the file frozen at 4096 bytes instead of growing to 4160.

Verified on Metal: full GPU suite and CPU-only suite pass. A run killed at 50% and resumed from its checkpoint produces a table byte-identical to the uninterrupted reference, with the first 64 KB unchanged across the resume.

Also bumps `version.h` to v1.5.4 — it had drifted to v1.3.1 while release tags advanced to v1.5.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)