### PR TITLE
fix(verify): stop truncated tables from being reported as verified

### DIFF
--- a/crackalack_tests.py
+++ b/crackalack_tests.py
@@ -24,6 +24,7 @@ REDB = "\033[1;31m";   # Red + bold
 
 GEN_PROG_NAME='crackalack_gen'
 LOOKUP_PROG_NAME='crackalack_lookup'
+VERIFY_PROG_NAME='crackalack_verify'
 
 CYGWIN=False
 if platform.system().startswith('CYGWIN'):
@@ -503,6 +504,53 @@ def do_lookup_test_5(temp_dir):
 
 # Deletes the pot file if it exists, along with all precompute files.  Creates the
 # rainbowtable directory.  Returns paths to the pot file and rainbow table directory.
+# Run the verify program with the given arguments.  Returns a
+# (returncode, combined_output) tuple.
+def run_verify(args):
+    proc = subprocess.run([verify_prog_path] + args, stdout=subprocess.PIPE,
+                          stderr=subprocess.STDOUT)
+    output = proc.stdout.decode('utf-8', errors='replace')
+    if VERBOSE:
+        print(output)
+
+    return proc.returncode, output
+
+
+# A table whose file size doesn't match the chain count in its filename is
+# truncated.  Verification must fail loudly instead of reporting success.
+def do_verify_test_truncated(temp_dir):
+    rt_dir = os.path.join(temp_dir, 'verify_truncated')
+    os.mkdir(rt_dir)
+
+    # The filename claims 1,000 chains, but only 100 are written.
+    path = create_rt_table(rt_dir, 'ntlm_ascii-32-95#8-8_0_1000x1000_0.rt', 100)
+
+    returncode, output = run_verify(['--raw', get_real_path(path)])
+
+    if returncode == 0:
+        print("  Expected a non-zero exit code for a truncated table, got 0.")
+        return False
+
+    if 'successfully verified' in output:
+        print("  Truncated table was reported as successfully verified.")
+        return False
+
+    return True
+
+
+# Do the verify tests.
+def do_verify_tests(temp_dir):
+    all_passed = True
+
+    if do_verify_test_truncated(temp_dir):
+        print("\t* Verify truncated-table test %spassed.%s" % (GREEN, CLR))
+    else:
+        print("%sFailed%s verify truncated-table test" % (RED, CLR))
+        all_passed = False
+
+    return all_passed
+
+
 def begin_lookup_test(path):
 
     # Delete the pot file if it exists.
@@ -527,11 +575,11 @@ if __name__ == '__main__':
 
     if (len(sys.argv) == 2) and (sys.argv[1] == '--verbose'):
         VERBOSE = True
-    elif (len(sys.argv) == 2) and (sys.argv[1] in ['precomp', 'lookup', 'generate']):
+    elif (len(sys.argv) == 2) and (sys.argv[1] in ['precomp', 'lookup', 'generate', 'verify']):
         tests_to_run = sys.argv[1]
         VERBOSE = True
     elif (len(sys.argv) == 2) and (sys.argv[1] == '--help'):
-        print("\nUsage: %s [precomp | lookup | generate | --verbose]\n\nWith no args, all tests are run.  Otherwise, the 'precomp', 'lookup', or 'generate' arguments will run those respective tests only (with verbose mode on).\n" % sys.argv[0])
+        print("\nUsage: %s [precomp | lookup | generate | verify | --verbose]\n\nWith no args, all tests are run.  Otherwise, the 'precomp', 'lookup', 'generate', or 'verify' arguments will run those respective tests only (with verbose mode on).\n" % sys.argv[0])
         exit(0)
 
     # NVIDIA caches old kernels in ~/.nv/ComputeCache.  We need to delete it so we're
@@ -549,6 +597,7 @@ if __name__ == '__main__':
     # to the crackalack_gen program.
     gen_prog_path = os.path.abspath(GEN_PROG_NAME)
     lookup_prog_path = os.path.abspath(LOOKUP_PROG_NAME)
+    verify_prog_path = os.path.abspath(VERIFY_PROG_NAME)
 
     # Make a temporary directory for us to generate tables in.
     temp_dir = tempfile.mkdtemp(prefix='crackalack_tests')
@@ -576,6 +625,13 @@ if __name__ == '__main__':
     if (tests_to_run == 'all') or (tests_to_run == 'lookup'):
         print("\n\nPerforming lookup tests...")
         all_passed = all_passed and do_lookup_tests(temp_dir)
+
+    if (tests_to_run == 'all') or (tests_to_run == 'verify'):
+        print("\n\nPerforming verify tests...")
+        # Evaluate first, then combine: `all_passed and do_verify_tests(...)`
+        # short-circuits and silently skips these tests once anything has failed.
+        verify_passed = do_verify_tests(temp_dir)
+        all_passed = all_passed and verify_passed
 
     if (tests_to_run == 'all') or (tests_to_run == 'generate'):
         print("\n\nPerforming generation tests...\n")

--- a/crackalack_tests.py
+++ b/crackalack_tests.py
@@ -134,6 +134,13 @@ def check_pot_file(pot_filename, plaintexts):
         else:
             return True
 
+    # A missing pot file means nothing was cracked.  That's a test failure, not a
+    # reason to raise: an exception here aborts the whole run, so every later test
+    # section is skipped.
+    if not os.path.exists(get_real_path(pot_filename)):
+        print("FAILED: pot file does not exist: %s\n  Expected plaintexts: %s" % (pot_filename, ', '.join(plaintexts)))
+        return False
+
     pot_lines = []
     with open(get_real_path(pot_filename), 'r') as f:
         for line in f:
@@ -618,18 +625,23 @@ if __name__ == '__main__':
 
     all_passed = True
 
+    # Each section evaluates its result before combining it into all_passed.
+    # Writing `all_passed = all_passed and do_x_tests(...)` short-circuits once
+    # anything has failed, so every later section is skipped -- while its header
+    # still prints, making the run look like it covered them.
+
     if (tests_to_run == 'all') or (tests_to_run == 'precomp'):
         print("Performing pre-computation tests...\n")
-        all_passed = all_passed and do_precomp_tests(temp_dir)
+        precomp_passed = do_precomp_tests(temp_dir)
+        all_passed = all_passed and precomp_passed
 
     if (tests_to_run == 'all') or (tests_to_run == 'lookup'):
         print("\n\nPerforming lookup tests...")
-        all_passed = all_passed and do_lookup_tests(temp_dir)
+        lookup_passed = do_lookup_tests(temp_dir)
+        all_passed = all_passed and lookup_passed
 
     if (tests_to_run == 'all') or (tests_to_run == 'verify'):
         print("\n\nPerforming verify tests...")
-        # Evaluate first, then combine: `all_passed and do_verify_tests(...)`
-        # short-circuits and silently skips these tests once anything has failed.
         verify_passed = do_verify_tests(temp_dir)
         all_passed = all_passed and verify_passed
 

--- a/verify.c
+++ b/verify.c
@@ -269,21 +269,26 @@ int verify_rainbowtable_file(char *filename, unsigned int table_type, unsigned i
   file_size = rc_ftell(f);
   rc_fseek(f, 0, RCSEEK_SET);
 
+  /* These size checks must return 0, not VERIFY_ERR_TRUNCATED: this function's
+   * contract is 1 on success / 0 on failure, and callers test the result for
+   * truthiness, so a nonzero error code reads as success.  See the note at the
+   * err: label below, where returning VERIFY_ERR_CORRUPTED was the same bug. */
+
   /* An empty file is always an error. */
   if (file_size == 0) {
     rc_fclose(f);
     fprintf(stderr, "Error: file is empty!\n");
-    return VERIFY_ERR_TRUNCATED;
+    return 0;
   /* If the table should be complete, then ensure its file size is what we'd expect.  Skip compressed files. */
   } else if ((table_should_be_complete == VERIFY_TABLE_IS_COMPLETE) && (file_size != (rt_params.num_chains * CHAIN_SIZE)) && !is_compressed) {
     rc_fclose(f);
     fprintf(stderr, "Error: table is expected to be complete, but file size does not match expected value.  Expected: %"PRIu64"; actual: %"PRIu64"\n", rt_params.num_chains * CHAIN_SIZE, file_size);
-    return VERIFY_ERR_TRUNCATED;
+    return 0;
   /* If the table is incomplete, ensure that the file size is a multiple of CHAIN_SIZE. */
   } else if (((file_size % CHAIN_SIZE) != 0) && !is_compressed) {
     rc_fclose(f);
     fprintf(stderr, "Error: file size is not aligned to %u bytes: %"PRIu64"\n", CHAIN_SIZE, file_size);
-    return VERIFY_ERR_TRUNCATED;
+    return 0;
   }
 
   /* Compressed tables cannot be quickly checked, as they currently require the entire table to be loaded into memory. */

--- a/version.h
+++ b/version.h
@@ -3,7 +3,7 @@
 
 #include "terminal_color.h"
 
-#define VERSION "v1.5.4"
+#define VERSION "v1.5.5"
 
 #define PRINT_PROJECT_HEADER() printf("\n%sRainbow Crackalack %s%s\nCopyright 2018-2021 Positron Security LLC <https://www.positronsecurity.com/>\n%s%s\n\n\n", WHITEB, VERSION, CLR, ITALICIZE, CLR);
 


### PR DESCRIPTION
## The bug

`verify_rainbowtable_file()`'s contract is 1 on success / 0 on failure, and every caller tests the result for truthiness. The three file-size checks returned `VERIFY_ERR_TRUNCATED`, which is **-2** — nonzero, therefore truthy, therefore read as success.

The result: a truncated table printed its error and was then reported as verified, with a zero exit code.

```
Error: table is expected to be complete, but file size does not match expected
value.  Expected: 3200000; actual: 420016
...
Rainbow table successfully verified!     <- exit code 0
```

This is the same defect that was already fixed once at the `err:` label in the same function, where returning `VERIFY_ERR_CORRUPTED` read as success — the comment there explains it. The size checks were the remaining instances. They now return 0.

## Why it matters

The predicate is shared, so this affected more than `crackalack_verify`:

- `crackalack_verify` in all modes
- the `--hcmask` batch path, which is the campaign-completeness check
- `crackalack_gen`'s post-generation verification (`crackalack_gen.c` uses the same truthiness test in two places)

It is easy to hit by accident: point verify at a compressed table, or at a table a crashed `gen` run left short, and you get a green result on a table that was never verified.

## Verification

- New CLI regression test: a table whose filename claims 1000 chains but holds 100 must make `crackalack_verify` exit non-zero and must not print "successfully verified". Confirmed failing before the fix (`Expected a non-zero exit code for a truncated table, got 0`) and passing after.
- Before/after on a real `.rt.zst`: exit 0 + "successfully verified" becomes exit 255 + "verification FAILED".
- CPU suite, Metal GPU suite, and all three generation tests in `crackalack_tests.py` pass (generation output is byte-identical, which is what confirms gen's verify path still works).

## Second commit: the harness was hiding tests

While adding the regression test I found `crackalack_tests.py` could not be trusted to report what it ran:

1. `all_passed = all_passed and do_x_tests(...)` short-circuits, so once any section failed every later section was skipped — while its header still printed. A pre-existing precomp failure on macOS meant **all five lookup tests never ran**.
2. `check_pot_file()` raised `FileNotFoundError` when the pot file was absent, aborting the whole run instead of failing one test.

Both fixed. With them fixed, the suite surfaces pre-existing failures that were previously invisible: lookup tests #1–#5 fail on macOS/Metal, with precalc hashes not matching expected values. **Deliberately left unfixed** — confirmed pre-existing by running this harness against unmodified master binaries, and the expected hashes must not be rubber-stamped without first determining whether the Metal precompute output is wrong or the expectations were captured on OpenCL/CUDA.

Version bumped to v1.5.5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)