### PR TITLE
chore: drop a dangling spec reference from the bloom FPR comment

### DIFF
--- a/crackalack_lookup.c
+++ b/crackalack_lookup.c
@@ -321,8 +321,7 @@ unsigned int fa_batch_threshold = 16384;
  * num_chains, which is twice the legacy bloom efficiency without
  * extra memory.  Tighter targets (e.g. 0.0001) land in a bigger
  * pow2 bucket and pay more in bloom-query work than they save in
- * binary-search work on this workload.  See
- * docs/superpowers/specs/2026-05-24-bloom-filter-tightening-design.md. */
+ * binary-search work on this workload. */
 double bloom_target_fpr = 0.01;
 
 /* Set to 1 when --bloom-fpr was given an explicit value > 0, which forces the


### PR DESCRIPTION
`crackalack_lookup.c` pointed at `docs/superpowers/specs/2026-05-24-bloom-filter-tightening-design.md`, which exists neither in this repo (`docs/` was extracted in `a6b09ae`) nor in `rainbowcrackalack-docs`.

The tuning rationale the pointer referred to is already stated inline in the same comment, so the reference is dropped rather than repaired.

Comment-only change; Metal build verified clean (0 warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)