### PR TITLE
fix(migrate): stop the .rtc migration from destroying outputs, and allow a read-only source

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,6 +64,28 @@ Sort before compressing: `--zst` deletes the raw `.rt`, and `crackalack_verify` 
 ./crackalack_sort --zst *.rt                # sort, compress, drop the raw .rt
 ```
 
+#### Bulk `.rtc` -> `.rt.zst` migration
+
+`scripts/migrate/migrate_netntlmv1_zst.py` converts a whole `.rtc` tree part by part
+(`rtc2rt` -> `rt2zst` -> `rt2zst -d` -> byte-identical `filecmp`), recording progress in a
+JSONL manifest so a run resumes without redoing finished parts. Tests:
+`python3 scripts/migrate/test_migrate_netntlmv1_zst.py` (stdlib `unittest`, no pytest, so it
+runs on bare hosts).
+
+Two things to get right, both learned the hard way:
+
+- **`--dest-dir` is mandatory when the source tree is a backup.** Without it the script
+  works in place and **deletes each `.rtc`** after a verified round trip. With it, outputs
+  mirror the source layout under a separate root and the source is never touched. Pointing
+  `--base-dir` at a read-only copy *without* `--dest-dir` would consume the backup.
+- **One driver per range, enforced by `driver_lock()`** — an exclusive `flock` on
+  `<manifest>.lock`. Two drivers sharing a range once destroyed 32 outputs: one deleted a
+  `.rtc` the other still had queued, whose failure cleanup then removed the good `.rt.zst`.
+  Give each host its own range *and* its own manifest.
+
+Note the driver's `print()` output is block-buffered when redirected to a log, so the log
+lags; **count manifest lines, not log lines**, to judge progress.
+
 ### Mask attacks
 
 Hashcat-style masks restrict each position to a specific character class, letting you cover structured password spaces (e.g. `Capital + 6 lower + digit`) with a much smaller table than full-charset coverage.

--- a/scripts/migrate/migrate_netntlmv1_zst.py
+++ b/scripts/migrate/migrate_netntlmv1_zst.py
@@ -23,6 +23,8 @@ Two modes:
       done, alongside the manifest.
 """
 import argparse
+import contextlib
+import fcntl
 import filecmp
 import hashlib
 import json
@@ -66,6 +68,33 @@ def discover_parts(base_dir, dir_names):
                 if fn.endswith('.rtc'):
                     parts.append(os.path.abspath(os.path.join(root, fn)))
     return sorted(parts)
+
+
+@contextlib.contextmanager
+def driver_lock(manifest_path):
+    """Guarantees only one driver per manifest, i.e. per range.
+
+    Ranges are the isolation boundary between hosts, but nothing used to enforce
+    one driver per range on a single host. On 2026-07-30 a relaunch left two
+    drivers on 3001-4095; they raced on the same parts and 32 outputs were
+    destroyed. An exclusive flock on <manifest>.lock makes that impossible.
+    The lock file is intentionally separate from the manifest so it can never
+    interfere with the append-only writes.
+    """
+    lock_path = manifest_path + '.lock'
+    fd = open(lock_path, 'w')
+    try:
+        try:
+            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except (OSError, IOError):
+            sys.exit('another driver already holds %s -- refusing to start a '
+                     'second driver on this range' % lock_path)
+        try:
+            yield
+        finally:
+            fcntl.flock(fd, fcntl.LOCK_UN)
+    finally:
+        fd.close()
 
 
 def dest_zst_path(rtc_path, base_dir, dest_dir):
@@ -125,11 +154,16 @@ def convert_one_part(rtc_path, rtc2rt_bin, rt2zst_bin, scratch_dir, zst_path=Non
     # may not exist yet on the first part landing in it.
     os.makedirs(os.path.dirname(zst_path), exist_ok=True)
 
+    # An output that is already here when we start belongs to a previous run or
+    # another worker. Cleaning up after our own failure must never destroy it --
+    # doing so cost 32 parts on 2026-07-30, recoverable only from the NAS backup.
+    zst_preexisted = os.path.exists(zst_path)
+
     def fail(detail):
         for p in (scratch_rt, scratch_check):
             if os.path.exists(p):
                 os.remove(p)
-        if os.path.exists(zst_path):
+        if not zst_preexisted and os.path.exists(zst_path):
             os.remove(zst_path)
         return {'part': rtc_path, 'status': 'error', 'detail': detail}
 
@@ -180,6 +214,11 @@ def main(argv=None, runner=subprocess.run):
                              '.rtc. Use when --base-dir is a read-only copy.')
     args = parser.parse_args(argv)
 
+    with driver_lock(args.manifest):
+        _run(args, runner)
+
+
+def _run(args, runner):
     os.makedirs(args.scratch_dir, exist_ok=True)
     dir_names = args.dirs.split(',')
     all_parts = discover_parts(args.base_dir, dir_names)

--- a/scripts/migrate/migrate_netntlmv1_zst.py
+++ b/scripts/migrate/migrate_netntlmv1_zst.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""Migrates NetNTLMv1 .rtc tables to .rt.zst.
+
+For each .rtc part: decompress to raw .rt, recompress to .rt.zst, verify the
+round trip is byte-identical, then clean up the scratch files. Progress is
+tracked in a JSONL manifest so an interrupted run can resume without
+reprocessing finished parts.
+
+Two modes:
+
+  in-place (no --dest-dir)
+      The .rt.zst is written beside the .rtc and the .rtc is DELETED once the
+      round-trip check passes. This is the original behaviour, used when the
+      source tree is the working copy being converted.
+
+  separate destination (--dest-dir)
+      The .rt.zst is written under --dest-dir, mirroring the source's layout
+      relative to --base-dir, and the source .rtc is NEVER deleted. Use this
+      when --base-dir is a read-only second copy (e.g. the NAS): the sources
+      stay intact as a backup and the destination host only ever receives
+      output. Because the source is immutable in this mode, an existing
+      non-empty .rt.zst in the destination is what marks a part as already
+      done, alongside the manifest.
+"""
+import argparse
+import filecmp
+import hashlib
+import json
+import multiprocessing
+import os
+import subprocess
+import sys
+
+
+def load_manifest(manifest_path):
+    """Reads a JSONL manifest, returns {part_path: entry_dict}."""
+    entries = {}
+    if not os.path.exists(manifest_path):
+        return entries
+    with open(manifest_path, 'r') as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            entry = json.loads(line)
+            entries[entry['part']] = entry
+    return entries
+
+
+def append_manifest(manifest_path, entry):
+    """Appends one JSON-encoded line to the manifest file."""
+    with open(manifest_path, 'a') as f:
+        f.write(json.dumps(entry) + '\n')
+
+
+def discover_parts(base_dir, dir_names):
+    """Returns a sorted list of absolute paths to every *.rtc file
+    found under base_dir/<name> for each name in dir_names."""
+    parts = []
+    for name in dir_names:
+        top = os.path.join(base_dir, name)
+        if not os.path.isdir(top):
+            continue
+        for root, _dirs, files in os.walk(top):
+            for fn in files:
+                if fn.endswith('.rtc'):
+                    parts.append(os.path.abspath(os.path.join(root, fn)))
+    return sorted(parts)
+
+
+def dest_zst_path(rtc_path, base_dir, dest_dir):
+    """Returns the .rt.zst output path for one .rtc part.
+
+    With dest_dir None the output is a sibling of the .rtc. Otherwise the
+    source's path relative to base_dir is mirrored under dest_dir, so a
+    read-only source tree (the NAS) maps onto a separate output tree.
+    """
+    if dest_dir is None:
+        return rtc_path[:-4] + '.rt.zst'
+    rel = os.path.relpath(rtc_path, os.path.abspath(base_dir))
+    return os.path.join(os.path.abspath(dest_dir), rel[:-4] + '.rt.zst')
+
+
+def pending_parts(all_parts, manifest, base_dir, dest_dir):
+    """Filters all_parts down to the ones still needing conversion.
+
+    A part is done if the manifest says so, or if its output already exists
+    and is non-empty. The second check matters because in --dest-dir mode the
+    source .rtc is never deleted, so the source tree cannot indicate progress
+    on its own -- and a zero-length output means an interrupted write, not a
+    finished part.
+    """
+    todo = []
+    for part in all_parts:
+        if manifest.get(part, {}).get('status') == 'done':
+            continue
+        out = dest_zst_path(part, base_dir, dest_dir)
+        if os.path.exists(out) and os.path.getsize(out) > 0:
+            continue
+        todo.append(part)
+    return todo
+
+
+def convert_one_part(rtc_path, rtc2rt_bin, rt2zst_bin, scratch_dir, zst_path=None,
+                     delete_source=True, zst_level=19, runner=subprocess.run):
+    """Runs rtc -> rt -> zst -> round-trip-check for one part.
+
+    zst_path defaults to a sibling of the .rtc. delete_source removes the
+    source .rtc after a verified round trip; pass False when the source tree
+    is a backup that must survive.
+    """
+    base = os.path.splitext(os.path.basename(rtc_path))[0]
+    # scratch_rt lives under scratch_dir (not beside the .rtc), so the large
+    # transient decompressed .rt can be written to fast local scratch storage
+    # even when the .rtc tree itself is on slower/remote storage (e.g. NFS).
+    # Part basenames repeat identically across many source subdirectories, so
+    # a hash of the full rtc_path is mixed in to keep scratch filenames unique
+    # across the whole tree (avoids collisions between parallel workers).
+    path_hash = hashlib.md5(rtc_path.encode()).hexdigest()[:12]
+    scratch_rt = os.path.join(scratch_dir, base + '.' + path_hash + '.rt')
+    scratch_check = os.path.join(scratch_dir, base + '.' + path_hash + '.rt.check')
+    if zst_path is None:
+        zst_path = rtc_path[:-4] + '.rt.zst'  # sibling of the .rtc, same directory
+    # The destination tree mirrors the source layout, so the part's directory
+    # may not exist yet on the first part landing in it.
+    os.makedirs(os.path.dirname(zst_path), exist_ok=True)
+
+    def fail(detail):
+        for p in (scratch_rt, scratch_check):
+            if os.path.exists(p):
+                os.remove(p)
+        if os.path.exists(zst_path):
+            os.remove(zst_path)
+        return {'part': rtc_path, 'status': 'error', 'detail': detail}
+
+    r = runner([rtc2rt_bin, rtc_path, scratch_rt])
+    if r.returncode != 0:
+        return fail('rtc2rt failed: ' + str(r.stderr))
+
+    r = runner([rt2zst_bin, '-l', str(zst_level), scratch_rt, zst_path])
+    if r.returncode != 0:
+        return fail('rt2zst compress failed: ' + str(r.stderr))
+
+    r = runner([rt2zst_bin, '-d', zst_path, scratch_check])
+    if r.returncode != 0:
+        return fail('rt2zst decompress-check failed: ' + str(r.stderr))
+
+    if not filecmp.cmp(scratch_rt, scratch_check, shallow=False):
+        return fail('round-trip byte mismatch')
+
+    orig_bytes = os.path.getsize(rtc_path)
+    new_bytes = os.path.getsize(zst_path)
+    os.remove(scratch_rt)
+    os.remove(scratch_check)
+    if delete_source:
+        os.remove(rtc_path)
+    return {'part': rtc_path, 'status': 'done', 'orig_bytes': orig_bytes, 'new_bytes': new_bytes}
+
+
+def _convert_worker(args):
+    rtc_path, rtc2rt_bin, rt2zst_bin, scratch_dir, zst_path, delete_source, zst_level = args
+    return convert_one_part(rtc_path, rtc2rt_bin, rt2zst_bin, scratch_dir,
+                            zst_path=zst_path, delete_source=delete_source,
+                            zst_level=zst_level)
+
+
+def main(argv=None, runner=subprocess.run):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--base-dir', required=True, help='e.g. /mnt/nvme/rtc/NetNTLMv1')
+    parser.add_argument('--dirs', required=True, help='comma-separated top-level dir names, e.g. 0-1000,1001-2000')
+    parser.add_argument('--workers', type=int, default=1)
+    parser.add_argument('--manifest', required=True)
+    parser.add_argument('--rtc2rt-bin', required=True)
+    parser.add_argument('--rt2zst-bin', required=True)
+    parser.add_argument('--scratch-dir', required=True)
+    parser.add_argument('--zst-level', type=int, default=19)
+    parser.add_argument('--dest-dir', default=None,
+                        help='write .rt.zst under this root, mirroring the layout '
+                             'relative to --base-dir, and never delete the source '
+                             '.rtc. Use when --base-dir is a read-only copy.')
+    args = parser.parse_args(argv)
+
+    os.makedirs(args.scratch_dir, exist_ok=True)
+    dir_names = args.dirs.split(',')
+    all_parts = discover_parts(args.base_dir, dir_names)
+    done = load_manifest(args.manifest)
+    todo = pending_parts(all_parts, done, args.base_dir, args.dest_dir)
+
+    # Deleting the source is only safe when it IS the working copy.
+    delete_source = args.dest_dir is None
+    print('Discovered %d parts, %d already done, %d to convert. Source .rtc will be %s.'
+          % (len(all_parts), len(all_parts) - len(todo), len(todo),
+             'DELETED after conversion' if delete_source else 'kept'))
+
+    work = [(p, args.rtc2rt_bin, args.rt2zst_bin, args.scratch_dir,
+             dest_zst_path(p, args.base_dir, args.dest_dir), delete_source,
+             args.zst_level)
+            for p in todo]
+
+    def record(result):
+        append_manifest(args.manifest, result)
+        print('%s: %s' % (result['status'].upper(), result['part']))
+
+    # A single worker runs in-process: it keeps an injected runner usable
+    # (a test double need not be picklable) and makes tracebacks readable.
+    if args.workers == 1:
+        for item in work:
+            rtc_path, rtc2rt_bin, rt2zst_bin, scratch_dir, zst_path, del_src, level = item
+            record(convert_one_part(rtc_path, rtc2rt_bin, rt2zst_bin, scratch_dir,
+                                    zst_path=zst_path, delete_source=del_src,
+                                    zst_level=level, runner=runner))
+        return
+
+    with multiprocessing.Pool(processes=args.workers) as pool:
+        for result in pool.imap_unordered(_convert_worker, work):
+            record(result)
+
+
+if __name__ == '__main__':
+    main(sys.argv[1:])

--- a/scripts/migrate/test_migrate_netntlmv1_zst.py
+++ b/scripts/migrate/test_migrate_netntlmv1_zst.py
@@ -1,0 +1,301 @@
+#!/usr/bin/env python3
+"""Tests for migrate_netntlmv1_zst.
+
+Uses stdlib unittest (not pytest) so this suite runs on the migration hosts
+with a bare python3, the same way the script itself does.
+
+Run: python3 scripts/migrate/test_migrate_netntlmv1_zst.py
+"""
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import migrate_netntlmv1_zst as m
+
+
+class FakeResult(object):
+    def __init__(self, returncode=0, stderr=''):
+        self.returncode = returncode
+        self.stderr = stderr
+
+
+class FakeTools(object):
+    """Stands in for crackalack_rtc2rt / crackalack_rt2zst.
+
+    Models the real byte behaviour closely enough to exercise the round-trip
+    check: 'rtc' payloads carry a marker that decompress expands and compress
+    reverses, so a corrupted step produces a genuine byte mismatch.
+    """
+
+    def __init__(self, fail_on=None, corrupt_roundtrip=False):
+        self.fail_on = fail_on or set()
+        self.corrupt_roundtrip = corrupt_roundtrip
+        self.calls = []
+
+    def run(self, argv):
+        binary = os.path.basename(argv[0])
+        self.calls.append(argv)
+
+        if binary == 'rtc2rt':
+            if 'rtc2rt' in self.fail_on:
+                return FakeResult(1, 'boom')
+            src, dst = argv[1], argv[2]
+            with open(src, 'rb') as f:
+                data = f.read()
+            with open(dst, 'wb') as f:
+                f.write(data + b'-EXPANDED')
+            return FakeResult()
+
+        if binary == 'rt2zst':
+            if argv[1] == '-d':
+                if 'decompress' in self.fail_on:
+                    return FakeResult(1, 'boom')
+                src, dst = argv[2], argv[3]
+                with open(src, 'rb') as f:
+                    data = f.read()
+                payload = data.replace(b'-ZSTD', b'')
+                if self.corrupt_roundtrip:
+                    payload += b'-TAMPERED'
+                with open(dst, 'wb') as f:
+                    f.write(payload)
+                return FakeResult()
+            if 'compress' in self.fail_on:
+                return FakeResult(1, 'boom')
+            src, dst = argv[3], argv[4]
+            with open(src, 'rb') as f:
+                data = f.read()
+            with open(dst, 'wb') as f:
+                f.write(data + b'-ZSTD')
+            return FakeResult()
+
+        raise AssertionError('unexpected binary: ' + binary)
+
+
+class MigrateTestCase(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp(prefix='migrate-test-')
+        self.base = os.path.join(self.tmp, 'src')
+        self.dest = os.path.join(self.tmp, 'dst')
+        self.scratch = os.path.join(self.tmp, 'scratch')
+        os.makedirs(self.scratch)
+        self.tools = FakeTools()
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def make_part(self, rel, payload=b'RTCDATA'):
+        path = os.path.join(self.base, rel)
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, 'wb') as f:
+            f.write(payload)
+        return path
+
+    def convert(self, rtc_path, zst_path=None, delete_source=True, tools=None):
+        tools = tools or self.tools
+        return m.convert_one_part(
+            rtc_path, 'rtc2rt', 'rt2zst', self.scratch,
+            zst_path=zst_path, delete_source=delete_source, runner=tools.run)
+
+
+class TestDestZstPath(MigrateTestCase):
+    def test_mirrors_relative_layout_under_dest(self):
+        rtc = self.make_part('1001-2000/1500/part_0.rtc')
+        got = m.dest_zst_path(rtc, self.base, self.dest)
+        self.assertEqual(
+            got, os.path.join(self.dest, '1001-2000/1500/part_0.rt.zst'))
+
+    def test_handles_trailing_slash_and_relative_base(self):
+        rtc = self.make_part('0-1000/7/part_1.rtc')
+        got = m.dest_zst_path(rtc, self.base + '/', self.dest)
+        self.assertEqual(
+            got, os.path.join(self.dest, '0-1000/7/part_1.rt.zst'))
+
+    def test_none_dest_means_in_place_sibling(self):
+        rtc = self.make_part('0-1000/7/part_1.rtc')
+        self.assertEqual(m.dest_zst_path(rtc, self.base, None),
+                         rtc[:-4] + '.rt.zst')
+
+
+class TestNasSourceMode(MigrateTestCase):
+    """dest_dir set => write to dest tree, and NEVER delete the source."""
+
+    def test_writes_output_to_dest_tree(self):
+        rtc = self.make_part('1001-2000/1500/part_0.rtc')
+        zst = m.dest_zst_path(rtc, self.base, self.dest)
+
+        result = self.convert(rtc, zst_path=zst, delete_source=False)
+
+        self.assertEqual(result['status'], 'done')
+        self.assertTrue(os.path.exists(zst), 'output not written to dest tree')
+
+    def test_creates_missing_dest_directories(self):
+        rtc = self.make_part('2001-3000/2400/part_2.rtc')
+        zst = m.dest_zst_path(rtc, self.base, self.dest)
+        self.assertFalse(os.path.isdir(os.path.dirname(zst)))
+
+        result = self.convert(rtc, zst_path=zst, delete_source=False)
+
+        self.assertEqual(result['status'], 'done')
+        self.assertTrue(os.path.exists(zst))
+
+    def test_source_is_preserved(self):
+        rtc = self.make_part('1001-2000/1500/part_0.rtc')
+        zst = m.dest_zst_path(rtc, self.base, self.dest)
+
+        self.convert(rtc, zst_path=zst, delete_source=False)
+
+        self.assertTrue(os.path.exists(rtc),
+                        'source .rtc was deleted -- this would destroy the NAS backup')
+
+    def test_no_output_written_beside_the_source(self):
+        rtc = self.make_part('1001-2000/1500/part_0.rtc')
+        zst = m.dest_zst_path(rtc, self.base, self.dest)
+
+        self.convert(rtc, zst_path=zst, delete_source=False)
+
+        self.assertFalse(os.path.exists(rtc[:-4] + '.rt.zst'),
+                         'wrote .rt.zst into the read-only source tree')
+
+    def test_scratch_is_cleaned_up(self):
+        rtc = self.make_part('1001-2000/1500/part_0.rtc')
+        zst = m.dest_zst_path(rtc, self.base, self.dest)
+
+        self.convert(rtc, zst_path=zst, delete_source=False)
+
+        self.assertEqual(os.listdir(self.scratch), [])
+
+    def test_failure_preserves_source_and_removes_partial_output(self):
+        rtc = self.make_part('1001-2000/1500/part_0.rtc')
+        zst = m.dest_zst_path(rtc, self.base, self.dest)
+        tools = FakeTools(corrupt_roundtrip=True)
+
+        result = self.convert(rtc, zst_path=zst, delete_source=False, tools=tools)
+
+        self.assertEqual(result['status'], 'error')
+        self.assertEqual(result['detail'], 'round-trip byte mismatch')
+        self.assertTrue(os.path.exists(rtc), 'source deleted on failure')
+        self.assertFalse(os.path.exists(zst), 'partial output left behind')
+        self.assertEqual(os.listdir(self.scratch), [])
+
+    def test_records_byte_counts(self):
+        rtc = self.make_part('1001-2000/1500/part_0.rtc')
+        zst = m.dest_zst_path(rtc, self.base, self.dest)
+
+        result = self.convert(rtc, zst_path=zst, delete_source=False)
+
+        self.assertEqual(result['orig_bytes'], os.path.getsize(rtc))
+        self.assertEqual(result['new_bytes'], os.path.getsize(zst))
+
+
+class TestLegacyInPlaceMode(MigrateTestCase):
+    """dest_dir absent => unchanged behaviour, including deleting the source."""
+
+    def test_writes_sibling_and_deletes_source(self):
+        rtc = self.make_part('0-1000/5/part_0.rtc')
+
+        result = self.convert(rtc, zst_path=None, delete_source=True)
+
+        self.assertEqual(result['status'], 'done')
+        self.assertTrue(os.path.exists(rtc[:-4] + '.rt.zst'))
+        self.assertFalse(os.path.exists(rtc), 'legacy mode must delete the .rtc')
+
+    def test_failure_keeps_source(self):
+        rtc = self.make_part('0-1000/5/part_0.rtc')
+        tools = FakeTools(fail_on={'compress'})
+
+        result = self.convert(rtc, zst_path=None, delete_source=True, tools=tools)
+
+        self.assertEqual(result['status'], 'error')
+        self.assertTrue(os.path.exists(rtc))
+
+
+class TestResumeSkipsCompletedOutputs(MigrateTestCase):
+    """With an immutable source, an existing dest .rt.zst is the resume signal."""
+
+    def test_pending_parts_excludes_parts_with_existing_output(self):
+        done_rtc = self.make_part('1001-2000/1/part_0.rtc')
+        todo_rtc = self.make_part('1001-2000/2/part_0.rtc')
+        done_zst = m.dest_zst_path(done_rtc, self.base, self.dest)
+        os.makedirs(os.path.dirname(done_zst))
+        with open(done_zst, 'wb') as f:
+            f.write(b'already-converted')
+
+        pending = m.pending_parts([done_rtc, todo_rtc], {}, self.base, self.dest)
+
+        self.assertEqual(pending, [todo_rtc])
+
+    def test_zero_length_output_is_not_treated_as_done(self):
+        rtc = self.make_part('1001-2000/1/part_0.rtc')
+        zst = m.dest_zst_path(rtc, self.base, self.dest)
+        os.makedirs(os.path.dirname(zst))
+        open(zst, 'wb').close()
+
+        pending = m.pending_parts([rtc], {}, self.base, self.dest)
+
+        self.assertEqual(pending, [rtc])
+
+    def test_manifest_done_still_skips(self):
+        rtc = self.make_part('1001-2000/1/part_0.rtc')
+        manifest = {rtc: {'status': 'done'}}
+
+        pending = m.pending_parts([rtc], manifest, self.base, self.dest)
+
+        self.assertEqual(pending, [])
+
+    def test_manifest_error_does_not_skip(self):
+        rtc = self.make_part('1001-2000/1/part_0.rtc')
+        manifest = {rtc: {'status': 'error', 'detail': 'transient'}}
+
+        pending = m.pending_parts([rtc], manifest, self.base, self.dest)
+
+        self.assertEqual(pending, [rtc])
+
+
+class TestCliWiring(MigrateTestCase):
+    def test_dest_dir_implies_source_is_kept(self):
+        rtc = self.make_part('1001-2000/1500/part_0.rtc')
+        m.main(['--base-dir', self.base, '--dirs', '1001-2000',
+                '--manifest', os.path.join(self.tmp, 'manifest.jsonl'),
+                '--rtc2rt-bin', 'rtc2rt', '--rt2zst-bin', 'rt2zst',
+                '--scratch-dir', self.scratch, '--dest-dir', self.dest,
+                '--workers', '1'], runner=self.tools.run)
+
+        self.assertTrue(os.path.exists(rtc), 'source deleted in --dest-dir mode')
+        self.assertTrue(os.path.exists(
+            m.dest_zst_path(rtc, self.base, self.dest)))
+
+    def test_manifest_records_absolute_source_path(self):
+        rtc = self.make_part('1001-2000/1500/part_0.rtc')
+        manifest_path = os.path.join(self.tmp, 'manifest.jsonl')
+        m.main(['--base-dir', self.base, '--dirs', '1001-2000',
+                '--manifest', manifest_path,
+                '--rtc2rt-bin', 'rtc2rt', '--rt2zst-bin', 'rt2zst',
+                '--scratch-dir', self.scratch, '--dest-dir', self.dest,
+                '--workers', '1'], runner=self.tools.run)
+
+        entries = m.load_manifest(manifest_path)
+        self.assertIn(rtc, entries)
+        self.assertEqual(entries[rtc]['status'], 'done')
+
+    def test_rerun_is_idempotent_and_does_no_work(self):
+        self.make_part('1001-2000/1500/part_0.rtc')
+        argv = ['--base-dir', self.base, '--dirs', '1001-2000',
+                '--manifest', os.path.join(self.tmp, 'manifest.jsonl'),
+                '--rtc2rt-bin', 'rtc2rt', '--rt2zst-bin', 'rt2zst',
+                '--scratch-dir', self.scratch, '--dest-dir', self.dest,
+                '--workers', '1']
+        m.main(argv, runner=self.tools.run)
+        calls_after_first = len(self.tools.calls)
+
+        m.main(argv, runner=self.tools.run)
+
+        self.assertEqual(len(self.tools.calls), calls_after_first,
+                         'second run reprocessed already-converted parts')
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/scripts/migrate/test_migrate_netntlmv1_zst.py
+++ b/scripts/migrate/test_migrate_netntlmv1_zst.py
@@ -44,6 +44,11 @@ class FakeTools(object):
             if 'rtc2rt' in self.fail_on:
                 return FakeResult(1, 'boom')
             src, dst = argv[1], argv[2]
+            # The real binary exits nonzero on a missing source rather than
+            # raising; this is exactly the production path that destroyed 32
+            # outputs, so the double has to reproduce it faithfully.
+            if not os.path.exists(src):
+                return FakeResult(1, 'cannot open %s' % src)
             with open(src, 'rb') as f:
                 data = f.read()
             with open(dst, 'wb') as f:
@@ -189,6 +194,106 @@ class TestNasSourceMode(MigrateTestCase):
 
         self.assertEqual(result['orig_bytes'], os.path.getsize(rtc))
         self.assertEqual(result['new_bytes'], os.path.getsize(zst))
+
+
+class TestFailureNeverDestroysAnotherWorkersOutput(MigrateTestCase):
+    """Regression: fail() used to remove zst_path unconditionally.
+
+    On 2026-07-30 two drivers ran against range 3001-4095. Worker A converted a
+    part and deleted its .rtc; worker B, still holding that part in its file
+    list, ran rtc2rt against the missing source, failed, and fail() deleted the
+    good .rt.zst worker A had just written. 32 parts ended up with neither a
+    .rtc nor a .rt.zst and had to be rebuilt from the NAS backup.
+
+    An output that already existed when this invocation started belongs to
+    someone else and must survive our failure.
+    """
+
+    def test_preexisting_output_survives_missing_source(self):
+        rtc = os.path.join(self.base, '3001-4095/3802/part_0.rtc')
+        os.makedirs(os.path.dirname(rtc))
+        # The exact production shape: source already gone, output already there.
+        zst = rtc[:-4] + '.rt.zst'
+        with open(zst, 'wb') as f:
+            f.write(b'GOOD-OUTPUT-FROM-ANOTHER-WORKER')
+
+        result = self.convert(rtc, zst_path=zst, delete_source=True)
+
+        self.assertEqual(result['status'], 'error')
+        self.assertTrue(os.path.exists(zst),
+                        'fail() destroyed an output it did not create')
+        with open(zst, 'rb') as f:
+            self.assertEqual(f.read(), b'GOOD-OUTPUT-FROM-ANOTHER-WORKER')
+
+    def test_preexisting_output_survives_compress_failure(self):
+        rtc = self.make_part('1001-2000/1500/part_0.rtc')
+        zst = m.dest_zst_path(rtc, self.base, self.dest)
+        os.makedirs(os.path.dirname(zst))
+        with open(zst, 'wb') as f:
+            f.write(b'PRE-EXISTING')
+        tools = FakeTools(fail_on={'compress'})
+
+        result = self.convert(rtc, zst_path=zst, delete_source=False, tools=tools)
+
+        self.assertEqual(result['status'], 'error')
+        self.assertTrue(os.path.exists(zst))
+        with open(zst, 'rb') as f:
+            self.assertEqual(f.read(), b'PRE-EXISTING')
+
+    def test_output_created_by_this_call_is_still_removed_on_failure(self):
+        """The cleanup we DO want must keep working."""
+        rtc = self.make_part('1001-2000/1500/part_0.rtc')
+        zst = m.dest_zst_path(rtc, self.base, self.dest)
+        self.assertFalse(os.path.exists(zst))
+        tools = FakeTools(corrupt_roundtrip=True)
+
+        result = self.convert(rtc, zst_path=zst, delete_source=False, tools=tools)
+
+        self.assertEqual(result['status'], 'error')
+        self.assertFalse(os.path.exists(zst),
+                         'our own partial output should be cleaned up')
+
+
+class TestDriverLock(MigrateTestCase):
+    """Two drivers on one range is what caused the loss; make it impossible."""
+
+    def test_second_driver_on_same_manifest_refuses_to_start(self):
+        self.make_part('1001-2000/1500/part_0.rtc')
+        manifest = os.path.join(self.tmp, 'manifest.jsonl')
+
+        with m.driver_lock(manifest):
+            with self.assertRaises(SystemExit):
+                with m.driver_lock(manifest):
+                    pass
+
+    def test_lock_is_released_after_use(self):
+        manifest = os.path.join(self.tmp, 'manifest.jsonl')
+
+        with m.driver_lock(manifest):
+            pass
+        # Must be re-acquirable; a stale lock would strand the campaign.
+        with m.driver_lock(manifest):
+            pass
+
+    def test_lock_released_even_if_run_raises(self):
+        manifest = os.path.join(self.tmp, 'manifest.jsonl')
+
+        try:
+            with m.driver_lock(manifest):
+                raise RuntimeError('boom')
+        except RuntimeError:
+            pass
+
+        with m.driver_lock(manifest):
+            pass
+
+    def test_different_manifests_do_not_block_each_other(self):
+        a = os.path.join(self.tmp, 'a.jsonl')
+        b = os.path.join(self.tmp, 'b.jsonl')
+
+        with m.driver_lock(a):
+            with m.driver_lock(b):
+                pass
 
 
 class TestLegacyInPlaceMode(MigrateTestCase):

--- a/version.h
+++ b/version.h
@@ -3,7 +3,7 @@
 
 #include "terminal_color.h"
 
-#define VERSION "v1.5.8"
+#define VERSION "v1.5.9"
 
 #define PRINT_PROJECT_HEADER() printf("\n%sRainbow Crackalack %s%s\nCopyright 2018-2021 Positron Security LLC <https://www.positronsecurity.com/>\n%s%s\n\n\n", WHITEB, VERSION, CLR, ITALICIZE, CLR);
 


### PR DESCRIPTION
## Why

The NetNTLMv1 `.rtc` -> `.rt.zst` migration lost 32 outputs in production on 2026-07-30. Two driver processes ended up on range `3001-4095` after a relaunch. Worker A converted a part and deleted its `.rtc`; worker B, still holding that part in its file list, ran `rtc2rt` against the now-missing source, failed — and `fail()` deleted the good `.rt.zst` worker A had just written, because it removed `zst_path` unconditionally. Those parts ended up with neither a `.rtc` nor a `.rt.zst`, recoverable only because a complete second copy of the `.rtc` set exists on a NAS.

Using that backup as a source was itself unsafe: the script derived the output path from the source path and deleted each `.rtc` after conversion, so pointing `--base-dir` at the backup would have written outputs onto it and consumed it.

## What

- **`--dest-dir`** mirrors the source layout under a separate root and never deletes the source, so a read-only copy can be the source. Without it, the previous in-place behaviour is unchanged. Because the source is then immutable, `pending_parts()` also treats a non-empty output as done (a zero-length one means an interrupted write).
- **`fail()` no longer deletes an output it did not create** — it records whether `zst_path` existed before this invocation started. Cleanup of its own partial output is unchanged.
- **`driver_lock()`** takes an exclusive non-blocking `flock` on `<manifest>.lock` for the whole run, so a second driver on the same range exits with a clear message instead of racing. Ranges were already the isolation boundary between hosts, but nothing enforced one driver per range on a host.
- The script and its first test suite are now tracked; until this PR they existed only on the migration hosts.

## Verification

- **26 tests**, stdlib `unittest` (no pytest) so they run on the hosts' bare `python3`. Green on macOS and on all three migration hosts.
- **Mutation-checked**: reintroducing the unconditional delete fails exactly 2 of them.
- **Byte-identical against the in-place path**: all 4 parts of `0-1000/5` converted from the NAS source are `cmp`-identical to the `.rt.zst` the in-place pipeline had already produced for those parts, with the NAS sources intact and nothing written into the source tree.
- **Lock verified on real hardware**: a second driver exits `rc=1` with `another driver already holds .../m.jsonl.lock`.
- **Recovery run in production**: 67/67 parts rebuilt from the NAS with zero errors; all 28 whose sources were then removed passed `zstd -t` first.
- Local CI gates pass: `make cpu-tests` + `./crackalack_cpu_tests` (all pass) and `make macos`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)