### PR TITLE
feat(lookup): add -ntlmv1 switch for end-to-end NetNTLMv1 cracking

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,6 +148,23 @@ printf '?u?l?l?l?l?l?d\n?d?l,?1?1?1?1\n' > masks.hcmask
 ./crackalack_lookup /path/to/tables/ hashes.txt --markov dynamic-all.markov
 ```
 
+### NetNTLMv1 one-shot lookup (-ntlmv1)
+
+`crackalack_lookup rainbow_table_directory -ntlmv1 capture_or_file` runs a full end-to-end NetNTLMv1 crack in one invocation: each capture's NT response is split into three DES blocks, the two 7-byte blocks are recovered via table lookup, the 2-byte block3 key is brute-forced (65536 keys, trivial on CPU), and the three recovered pieces are reassembled into the full 16-byte NTLM hash.
+
+- **Capture format** is a hashcat `-m 5500` capture line: `user::domain:LMresponse:NTresponse:serverchallenge` (LM/NT responses are 48 hex chars, challenge is 16 hex chars). `capture_or_file` may be a single capture line or a path to a file containing one capture per line.
+- **ESS/NTLM2-Session captures are detected and skipped.** ESS uses a random per-session client challenge that defeats precomputed tables regardless of how it's folded into the hash, so these captures are reported and skipped rather than attempted.
+- **Tables are challenge-specific.** Any capture whose effective challenge doesn't match the loaded tables' challenge is also skipped and reported. If every capture in a run is ESS, the program exits cleanly (exit 0) rather than with an error, since that's an expected outcome rather than a failure.
+- **Pot-file entries use the verbatim original capture line as the key** (not a reconstruction from parsed fields), matching real hashcat `-m 5500` pot syntax exactly — so a hashcat run against that same original capture line recognizes it as already cracked. The recovered full NTLM hash is stored as the corresponding "cracked value."
+
+```bash
+# One-shot NetNTLMv1 crack from a capture line
+./crackalack_lookup /path/to/netntlmv1_tables/ -ntlmv1 'alice::CORP:aabbccdd...48hex...:11223344...48hex...:aabbccddeeff0011'
+
+# Or from a file of captures, one per line
+./crackalack_lookup /path/to/netntlmv1_tables/ -ntlmv1 captures.txt
+```
+
 ## Tests
 
 Unit tests require a GPU (CUDA on Linux, OpenCL on Windows, Metal on macOS):

--- a/Makefile
+++ b/Makefile
@@ -460,6 +460,7 @@ LOOKUP_OBJS := \
 	$(OBJDIR)/markov_mask.o \
 	$(OBJDIR)/mask_parse.o \
 	$(OBJDIR)/misc.o \
+	$(OBJDIR)/netntlmv1_capture.o \
 	$(OBJDIR)/precompute_collate.o \
 	$(GPU_BACKEND_OBJ) \
 	$(OBJDIR)/rar_decompress.o \

--- a/Makefile
+++ b/Makefile
@@ -184,6 +184,8 @@ CPU_TESTS_OBJS := \
 	$(CPU_TESTS_OBJDIR)/cpu_tests_common.o \
 	$(CPU_TESTS_OBJDIR)/test_challenge_host.o \
 	$(CPU_TESTS_OBJDIR)/test_misc.o \
+	$(CPU_TESTS_OBJDIR)/netntlmv1_capture.o \
+	$(CPU_TESTS_OBJDIR)/test_netntlmv1_capture.o \
 	$(CPU_TESTS_OBJDIR)/test_bloom.o \
 	$(CPU_TESTS_OBJDIR)/test_sort.o \
 	$(CPU_TESTS_OBJDIR)/test_decompress.o \
@@ -352,6 +354,7 @@ UNITTEST_OBJS := \
 	$(OBJDIR)/gws.o \
 	$(OBJDIR)/hash_validate.o \
 	$(OBJDIR)/misc.o \
+	$(OBJDIR)/netntlmv1_capture.o \
 	$(GPU_BACKEND_OBJ) \
 	$(OBJDIR)/test_bloom.o \
 	$(OBJDIR)/test_chain.o \
@@ -367,6 +370,7 @@ UNITTEST_OBJS := \
 	$(OBJDIR)/test_hash_to_index.o \
 	$(OBJDIR)/test_hash_to_index_netntlmv1.o \
 	$(OBJDIR)/test_hash_to_index_ntlm9.o \
+	$(OBJDIR)/test_netntlmv1_capture.o \
 	$(OBJDIR)/test_index_to_plaintext.o \
 	$(OBJDIR)/test_index_to_plaintext_ntlm9.o \
 	$(OBJDIR)/test_index_to_plaintext_markov.o \

--- a/README.md
+++ b/README.md
@@ -208,6 +208,14 @@ The challenge is encoded into the table filename — non-default challenges get 
 
 If you need to override it (e.g. tables without the challenge in their names), pass `--challenge aabbccddeeff0011` to `crackalack_lookup` as well. Note that the precompute cache key includes a non-default challenge, so switching challenges will not produce stale cross-challenge false negatives.
 
+#### One-shot Net-NTLMv1 cracking (-ntlmv1)
+
+Instead of manually splitting a captured Net-NTLMv1 response into DES fragments, `crackalack_lookup` can take a full hashcat `-m 5500` capture line (or a file of them, one per line) and do everything end-to-end — split, lookup, brute-force the remaining 2-byte block, and reassemble the full 16-byte NTLM hash:
+
+    # ./crackalack_lookup /export/netntlmv1_tables/ -ntlmv1 'alice::CORP:<48-hex LM>:<48-hex NT>:<16-hex challenge>'
+
+ESS/NTLM2-Session captures (random per-session client challenge) and captures whose challenge doesn't match the loaded tables are detected and skipped automatically. The pot-file entry for a cracked capture uses the verbatim original capture line as its key, matching real hashcat `-m 5500` pot syntax.
+
 #### Table lookups against NTLM 8-character hashes
 
 The following command shows how to look up a file of NTLM hashes (one per line) against the NTLM 8-character tables:

--- a/crackalack_lookup.c
+++ b/crackalack_lookup.c
@@ -4220,8 +4220,12 @@ static int load_netntlmv1_captures(const char *arg, netntlmv1_capture **out_capt
         capacity *= 2;
         tmp = realloc(captures, capacity * sizeof(netntlmv1_capture));
         if (tmp == NULL) {
+          unsigned int j;
+
           fprintf(stderr, "Error while growing buffer for NetNTLMv1 captures.\n");
           FCLOSE(f);
+          for (j = 0; j < count; j++)
+            netntlmv1_free_capture(&captures[j]);
           FREE(captures);
           return -1;
         }
@@ -4772,6 +4776,17 @@ int main(int ac, char **av) {
       synthetic_ppi.plaintext = full_ntlm_hex;
       synthetic_ppi.index_filename = NULL;
       save_cracked_hash(&synthetic_ppi, HASH_NETNTLMV1);
+      /* save_cracked_hash() unconditionally does num_cracked++ and
+       * num_falsealarms--, on the assumption that every call represents a
+       * newly-cracked hash from the normal pipeline.  This synthetic entry
+       * is not one: the two block cracks that made reassembly possible here
+       * already incremented num_cracked (and adjusted num_falsealarms) via
+       * their own save_cracked_hash() calls earlier in the pipeline.
+       * Compensate here so the pot file still gets the new reassembled
+       * entry appended, but the final report's counters aren't
+       * triple-counted or driven negative (num_falsealarms is unsigned). */
+      num_cracked--;
+      num_falsealarms++;
     }
   }
 

--- a/crackalack_lookup.c
+++ b/crackalack_lookup.c
@@ -55,6 +55,7 @@
 #include "mask_parse.h"
 #include "bloom.h"
 #include "misc.h"
+#include "netntlmv1_capture.h"
 #include "fa_batch.h"
 #include "precompute_collate.h"
 #ifdef HAVE_UNRAR
@@ -3294,13 +3295,14 @@ void print_usage_and_exit(char *prog_name, int exit_code) {
   char *dir2 = "/home/user/";
 #endif
 
-  fprintf(stderr, "%sUsage:%s %s rainbow_table_directory (single_hash | filename_with_many_hashes.txt) [-gws GWS] [-disable-platform N]\n\n", WHITEB, CLR, prog_name);
+  fprintf(stderr, "%sUsage:%s %s rainbow_table_directory (single_hash | filename_with_many_hashes.txt | -ntlmv1 capture_or_file) [-gws GWS] [-disable-platform N]\n\n", WHITEB, CLR, prog_name);
   fprintf(stderr, "    %s-gws GWS%s    (Optional) Sets the global work size for each GPU.  This can significantly affect the speed.  To tune this setting, start with multiplying the max compute units by the max work group size (both are reported on program start-up).  Then increase/decrease the value and time the results.  For example, if the max compute units is 20, and the max work group size is 1024, try using 20 x 1024 = 20480, then 20480 - 1024 = 19456, 20480 - 2048 = 18432, 2048 + 1024 = 21504, etc.  If you find a value that works better than the automatic setting, please report your findings at: https://github.com/jtesta/rainbowcrackalack/issues\n\n", WHITEB, CLR);
   fprintf(stderr, "    %s-disable-platform N%s    (Optional) Disables a platform from being used (platform numbers are reported on program start-up).  Useful when experiencing strange problems on mixed-GPU systems.  Try disabling each platform one at a time and see if the program behaves normally.\n\n", WHITEB, CLR);
   fprintf(stderr, "    %s--fa-batch N%s    (Optional) False-alarm batch flush threshold (default 16384; 1 disables batching).\n\n", WHITEB, CLR);
   fprintf(stderr, "    %s--bloom-fpr X%s    (Optional) Bloom filter target false-positive rate (default 0.01; 0 disables).\n\n", WHITEB, CLR);
   fprintf(stderr, "    %s--gpu-search%s    (Optional) Offload per-table endpoint binary search to the GPU.  Off by default while still under validation.\n\n", WHITEB, CLR);
   fprintf(stderr, "    %s--challenge HEX%s    (Optional) NetNTLMv1 server challenge as 16 hex digits (default 1122334455667788).  Normally adopted automatically from the loaded tables.\n\n", WHITEB, CLR);
+  fprintf(stderr, "    %s-ntlmv1 capture_or_file%s    Given a full NetNTLMv1 capture (\"user::domain:LMresp:NTresp:challenge\") or a file of one capture per line, splits the NT response into its three DES blocks, cracks block1/block2 via the loaded tables, brute-forces block3's 2-byte key, and prints/pot-files the reassembled 16-byte NTLM hash.  ESS/NTLM2-Session captures are detected and skipped (their random per-session client challenge defeats precomputed tables).  Mutually exclusive with the positional single_hash/filename argument.\n\n", WHITEB, CLR);
   fprintf(stderr, "%sExamples:%s\n    %s %s 64f12cddaa88057e06a81b54e73b949b\n    %s %s %shashes_one_per_line.txt\n    %s %s %spwdump.txt\n\n", WHITEB, CLR, prog_name, dir1, prog_name, dir1, dir2, prog_name, dir1, dir2);
   exit(exit_code);
 }
@@ -4157,6 +4159,92 @@ void search_tables(unsigned int total_tables, precomputed_and_potential_indices 
 }
 
 
+static int ntlmv1_mode = 0;
+static char *ntlmv1_arg = NULL;
+
+/* Loads NetNTLMv1 captures from `arg`.  If `arg` opens as a readable file,
+ * every non-blank, non-'#'-prefixed line is parsed as one capture (bad
+ * lines are warned about and skipped, not fatal).  Otherwise `arg` itself
+ * is parsed as a single capture line.  Returns 0 on success (even with
+ * zero valid captures -- caller checks *out_count), -1 on allocation or
+ * single-line-parse failure. */
+static int load_netntlmv1_captures(const char *arg, netntlmv1_capture **out_captures, unsigned int *out_count) {
+  FILE *f = fopen(arg, "rb");
+  netntlmv1_capture *captures = NULL;
+  unsigned int count = 0, capacity = 0;
+  char errbuf[256];
+
+  if (f == NULL) {
+    captures = calloc(1, sizeof(netntlmv1_capture));
+    if (captures == NULL) {
+      fprintf(stderr, "Error while allocating buffer for NetNTLMv1 capture.\n");
+      return -1;
+    }
+
+    if (netntlmv1_parse_capture_line(arg, &captures[0], errbuf, sizeof(errbuf)) != 0) {
+      fprintf(stderr, "Error parsing NetNTLMv1 capture: %s\n", errbuf);
+      free(captures);
+      return -1;
+    }
+
+    *out_captures = captures;
+    *out_count = 1;
+    return 0;
+  }
+
+  {
+    char line[1024];
+    unsigned int line_num = 0;
+
+    capacity = 16;
+    captures = calloc(capacity, sizeof(netntlmv1_capture));
+    if (captures == NULL) {
+      fprintf(stderr, "Error while allocating buffer for NetNTLMv1 captures.\n");
+      FCLOSE(f);
+      return -1;
+    }
+
+    while (fgets(line, sizeof(line), f) != NULL) {
+      char *p = line;
+
+      line_num++;
+
+      while (*p == ' ' || *p == '\t')
+        p++;
+      if (*p == '\0' || *p == '\n' || *p == '\r' || *p == '#')
+        continue;
+
+      if (count == capacity) {
+        netntlmv1_capture *tmp;
+
+        capacity *= 2;
+        tmp = realloc(captures, capacity * sizeof(netntlmv1_capture));
+        if (tmp == NULL) {
+          fprintf(stderr, "Error while growing buffer for NetNTLMv1 captures.\n");
+          FCLOSE(f);
+          FREE(captures);
+          return -1;
+        }
+        captures = tmp;
+      }
+
+      if (netntlmv1_parse_capture_line(line, &captures[count], errbuf, sizeof(errbuf)) != 0) {
+        fprintf(stderr, "Warning: %s, line %u: %s -- skipping.\n", arg, line_num, errbuf);
+        continue;
+      }
+
+      count++;
+    }
+
+    FCLOSE(f);
+  }
+
+  *out_captures = captures;
+  *out_count = count;
+  return 0;
+}
+
+
 int main(int ac, char **av) {
   char *rt_dir = NULL, *single_hash = NULL, *filename = NULL, *file_data = NULL, **usernames = NULL, **hashes = NULL, *pot_file_data = NULL;
   unsigned int i = 0;
@@ -4180,11 +4268,23 @@ int main(int ac, char **av) {
   setlocale(LC_NUMERIC, "");
   init_max_preload_num();
   memcpy(g_challenge, NETNTLMV1_DEFAULT_CHALLENGE, 8);
+  unsigned int flags_start = 3;
+
   if (ac < 3)
     print_usage_and_exit(av[0], -1);
 
-  /* Parse optional flags (everything after the first two positional args). */
-  for (i = 3; i < (unsigned int)ac; i++) {
+  if (strcmp(av[2], "-ntlmv1") == 0) {
+    if (ac < 4) {
+      fprintf(stderr, "Error: -ntlmv1 requires a capture string or file path.\n");
+      print_usage_and_exit(av[0], -1);
+    }
+    ntlmv1_mode = 1;
+    ntlmv1_arg = av[3];
+    flags_start = 4;
+  }
+
+  /* Parse optional flags (everything after the first two/three positional args). */
+  for (i = flags_start; i < (unsigned int)ac; i++) {
     if ((strcmp(av[i], "-gws") == 0) && (i + 1 < (unsigned int)ac)) {
       user_provided_gws = parse_uint_arg(av[++i], "-gws");
     } else if ((strcmp(av[i], "-disable-platform") == 0) && (i + 1 < (unsigned int)ac)) {
@@ -4301,7 +4401,11 @@ int main(int ac, char **av) {
   FCLOSE(f);
 
   /* Check if the second arg is a hash or a file containing hashes. */
-  if (stat(av[2], &st) == 0)
+  if (ntlmv1_mode) {
+    /* Nothing to do here -- hashes[]/usernames[] are built below, after the
+     * config groups are loaded and the active NetNTLMv1 challenge is
+     * resolved from them. */
+  } else if (stat(av[2], &st) == 0)
     filename = av[2];
   else {
     single_hash = av[2];
@@ -4316,7 +4420,9 @@ int main(int ac, char **av) {
     }
   }
 
-  if (filename) {
+  if (ntlmv1_mode) {
+    /* Handled after config groups are loaded, below. */
+  } else if (filename) {
     FILE *f = fopen(filename, "rb");
     unsigned int previously_cracked = 0;
 
@@ -4382,6 +4488,11 @@ int main(int ac, char **av) {
    * shrink the uncracked-hash set before the expensive groups run. */
   sort_config_groups(&cg_head);
 
+  if (ntlmv1_mode && cg_head->params.hash_type != HASH_NETNTLMV1) {
+    fprintf(stderr, "Error: -ntlmv1 requires NetNTLMv1 rainbow tables; loaded tables in %s are a different hash type.\n", rt_dir);
+    exit(-1);
+  }
+
   /* Use the first config group's hash type for hash format validation. */
   if (cg_head->params.hash_type == HASH_NTLM) {
     for (i = 0; i < num_hashes; i++) {
@@ -4428,6 +4539,69 @@ int main(int ac, char **av) {
     memcpy(g_challenge, table_challenge, 8);
     g_challenge_set = 1;
     set_netntlmv1_challenge(g_challenge);
+  }
+
+  netntlmv1_capture *ntlmv1_captures = NULL;
+  unsigned int num_ntlmv1_captures = 0;
+  unsigned int *ntlmv1_capture_queued = NULL;
+
+  if (ntlmv1_mode) {
+    if (load_netntlmv1_captures(ntlmv1_arg, &ntlmv1_captures, &num_ntlmv1_captures) != 0)
+      goto err;
+
+    if (num_ntlmv1_captures == 0) {
+      fprintf(stderr, "Error: no valid NetNTLMv1 captures were parsed from '%s'.\n", ntlmv1_arg);
+      exit(-1);
+    }
+
+    ntlmv1_capture_queued = calloc(num_ntlmv1_captures, sizeof(unsigned int));
+    usernames = calloc((size_t)num_ntlmv1_captures * 2, sizeof(char *));
+    hashes    = calloc((size_t)num_ntlmv1_captures * 2, sizeof(char *));
+    if (ntlmv1_capture_queued == NULL || usernames == NULL || hashes == NULL) {
+      fprintf(stderr, "Error while allocating buffers for NetNTLMv1 captures.\n");
+      goto err;
+    }
+
+    num_hashes = 0;
+    for (i = 0; i < num_ntlmv1_captures; i++) {
+      netntlmv1_capture *cap = &ntlmv1_captures[i];
+      unsigned char effective_challenge[8], block1[8], block2[8], block3[8];
+      char block1_hex[17] = {0}, block2_hex[17] = {0};
+
+      if (cap->is_ess) {
+        printf("capture %u: ESS/NTLM2-Session detected -- client challenge is random per-session, precomputed tables cannot cover this, skipping\n", i + 1);
+        continue;
+      }
+
+      netntlmv1_effective_challenge(cap, effective_challenge);
+
+      if (memcmp(effective_challenge, g_challenge, 8) != 0) {
+        char a[17] = {0}, b[17] = {0};
+        format_challenge_hex(effective_challenge, a);
+        format_challenge_hex(g_challenge, b);
+        printf("capture %u: challenge %s doesn't match loaded tables' challenge %s, skipping\n", i + 1, a, b);
+        continue;
+      }
+
+      netntlmv1_split_nt_response(cap->nt_response, block1, block2, block3);
+      netntlmv1_hex_encode(block1, 8, block1_hex);
+      netntlmv1_hex_encode(block2, 8, block2_hex);
+
+      usernames[num_hashes] = NULL;
+      hashes[num_hashes] = strdup(block1_hex);
+      num_hashes++;
+
+      usernames[num_hashes] = NULL;
+      hashes[num_hashes] = strdup(block2_hex);
+      num_hashes++;
+
+      ntlmv1_capture_queued[i] = 1;
+    }
+
+    if (num_hashes == 0) {
+      fprintf(stderr, "Error: no NetNTLMv1 captures matched the loaded tables' challenge.\n");
+      exit(-1);
+    }
   }
 
   /* Issue a warning if more than 5,000 hashes were provided, as rainbow tables may
@@ -4540,6 +4714,67 @@ int main(int ac, char **av) {
 
   free_config_groups(&cg_head);
 
+  if (ntlmv1_mode) {
+    for (i = 0; i < num_ntlmv1_captures; i++) {
+      netntlmv1_capture *cap = &ntlmv1_captures[i];
+      unsigned char block1[8], block2[8], block3[8];
+      char block1_hex[17] = {0}, block2_hex[17] = {0};
+      precomputed_and_potential_indices *ppi1, *ppi2;
+      unsigned char key1[7], key2[7], key3[2];
+      unsigned char full_ntlm[16];
+      char full_ntlm_hex[33] = {0};
+      char capture_line[512] = {0};
+      char lm_hex[49] = {0}, nt_hex[49] = {0}, chal_hex[17] = {0};
+      precomputed_and_potential_indices synthetic_ppi;
+
+      if (!ntlmv1_capture_queued[i])
+        continue;
+
+      netntlmv1_split_nt_response(cap->nt_response, block1, block2, block3);
+      netntlmv1_hex_encode(block1, 8, block1_hex);
+      netntlmv1_hex_encode(block2, 8, block2_hex);
+
+      ppi1 = ppi_find(ppi_head, block1_hex);
+      ppi2 = ppi_find(ppi_head, block2_hex);
+
+      if (ppi1 == NULL || ppi1->plaintext == NULL) {
+        printf("capture %u (%s): block1 (%s) not found in tables -- cannot reassemble full NTLM hash.\n", i + 1, cap->user, block1_hex);
+        continue;
+      }
+      if (ppi2 == NULL || ppi2->plaintext == NULL) {
+        printf("capture %u (%s): block2 (%s) not found in tables -- cannot reassemble full NTLM hash.\n", i + 1, cap->user, block2_hex);
+        continue;
+      }
+
+      if (netntlmv1_hex_decode(ppi1->plaintext, 14, key1) != 0 ||
+          netntlmv1_hex_decode(ppi2->plaintext, 14, key2) != 0) {
+        fprintf(stderr, "capture %u (%s): internal error decoding recovered key hex.\n", i + 1, cap->user);
+        continue;
+      }
+
+      if (netntlmv1_bruteforce_block3(block3, g_challenge, key3) != 0) {
+        fprintf(stderr, "capture %u (%s): internal error -- exhaustive 2-byte block3 search found no match (this should never happen).\n", i + 1, cap->user);
+        continue;
+      }
+
+      netntlmv1_assemble_ntlm_hash(key1, key2, key3, full_ntlm);
+      netntlmv1_hex_encode(full_ntlm, 16, full_ntlm_hex);
+
+      printf("%sHASH CRACKED (NetNTLMv1, full NTLM hash) => %s:%s:%s%s\n", GREENB, cap->user, cap->domain, full_ntlm_hex, CLR);
+
+      netntlmv1_hex_encode(cap->lm_response, 24, lm_hex);
+      netntlmv1_hex_encode(cap->nt_response, 24, nt_hex);
+      netntlmv1_hex_encode(cap->server_challenge, 8, chal_hex);
+      snprintf(capture_line, sizeof(capture_line), "%s::%s:%s:%s:%s", cap->user, cap->domain, lm_hex, nt_hex, chal_hex);
+
+      memset(&synthetic_ppi, 0, sizeof(synthetic_ppi));
+      synthetic_ppi.hash = capture_line;
+      synthetic_ppi.plaintext = full_ntlm_hex;
+      synthetic_ppi.index_filename = NULL;
+      save_cracked_hash(&synthetic_ppi, HASH_NETNTLMV1);
+    }
+  }
+
   seconds_to_human_time(time_precomp_str, sizeof(time_precomp_str), time_precomp);
   seconds_to_human_time(time_io_str, sizeof(time_io_str), time_io);
   seconds_to_human_time(time_searching_str, sizeof(time_searching_str), time_searching);
@@ -4573,6 +4808,13 @@ int main(int ac, char **av) {
 
   printf(" %s* Statistics *%s\n\n          Number of tables processed: %u\n              Number of false alarms: %" QUOTE PRIu64"\n          Number of chains processed: %" QUOTE PRIu64"\n\n                Time spent per table: %s\n     False alarms checked per second: %" QUOTE ".1f\n\n         False alarms per no. chains: %.5f%%\n  Successful cracks per false alarms: %.5f%%\n  Successful cracks per total chains: %.8f%%\n\n\n", WHITEB, CLR, num_tables_processed, num_falsealarms, num_chains_processed, time_per_table_str, (double)num_falsealarms / time_falsealarms, ((double)num_falsealarms / (double)num_chains_processed) * 100.0, ((double)num_cracked / (double)num_falsealarms) * 100.0, ((double)num_cracked / (double)num_chains_processed) * 100.0);
 
+
+  if (ntlmv1_mode) {
+    for (i = 0; i < num_ntlmv1_captures; i++)
+      netntlmv1_free_capture(&ntlmv1_captures[i]);
+    FREE(ntlmv1_captures);
+    FREE(ntlmv1_capture_queued);
+  }
 
   free_precomputed_and_potential_indices(&ppi_head);
   free_loaded_hashes(usernames, hashes);

--- a/crackalack_lookup.c
+++ b/crackalack_lookup.c
@@ -4567,6 +4567,8 @@ int main(int ac, char **av) {
     }
 
     num_hashes = 0;
+    int any_ess_skipped = 0;
+    int any_mismatch_skipped = 0;
     for (i = 0; i < num_ntlmv1_captures; i++) {
       netntlmv1_capture *cap = &ntlmv1_captures[i];
       unsigned char effective_challenge[8], block1[8], block2[8], block3[8];
@@ -4574,6 +4576,8 @@ int main(int ac, char **av) {
 
       if (cap->is_ess) {
         printf("capture %u: ESS/NTLM2-Session detected -- client challenge is random per-session, precomputed tables cannot cover this, skipping\n", i + 1);
+        fflush(stdout);
+        any_ess_skipped = 1;
         continue;
       }
 
@@ -4584,6 +4588,8 @@ int main(int ac, char **av) {
         format_challenge_hex(effective_challenge, a);
         format_challenge_hex(g_challenge, b);
         printf("capture %u: challenge %s doesn't match loaded tables' challenge %s, skipping\n", i + 1, a, b);
+        fflush(stdout);
+        any_mismatch_skipped = 1;
         continue;
       }
 
@@ -4603,8 +4609,17 @@ int main(int ac, char **av) {
     }
 
     if (num_hashes == 0) {
-      fprintf(stderr, "Error: no NetNTLMv1 captures matched the loaded tables' challenge.\n");
-      exit(-1);
+      if (any_mismatch_skipped) {
+        fprintf(stderr, "Error: no NetNTLMv1 captures matched the loaded tables' challenge.\n");
+        exit(-1);
+      } else if (any_ess_skipped) {
+        printf("All %u capture(s) were ESS/NTLM2-Session -- none can be attempted with precomputed tables.\n", num_ntlmv1_captures);
+        fflush(stdout);
+        exit(0);
+      } else {
+        fprintf(stderr, "Error: no NetNTLMv1 captures matched the loaded tables' challenge.\n");
+        exit(-1);
+      }
     }
   }
 
@@ -4727,8 +4742,6 @@ int main(int ac, char **av) {
       unsigned char key1[7], key2[7], key3[2];
       unsigned char full_ntlm[16];
       char full_ntlm_hex[33] = {0};
-      char capture_line[512] = {0};
-      char lm_hex[49] = {0}, nt_hex[49] = {0}, chal_hex[17] = {0};
       precomputed_and_potential_indices synthetic_ppi;
 
       if (!ntlmv1_capture_queued[i])
@@ -4766,13 +4779,8 @@ int main(int ac, char **av) {
 
       printf("%sHASH CRACKED (NetNTLMv1, full NTLM hash) => %s:%s:%s%s\n", GREENB, cap->user, cap->domain, full_ntlm_hex, CLR);
 
-      netntlmv1_hex_encode(cap->lm_response, 24, lm_hex);
-      netntlmv1_hex_encode(cap->nt_response, 24, nt_hex);
-      netntlmv1_hex_encode(cap->server_challenge, 8, chal_hex);
-      snprintf(capture_line, sizeof(capture_line), "%s::%s:%s:%s:%s", cap->user, cap->domain, lm_hex, nt_hex, chal_hex);
-
       memset(&synthetic_ppi, 0, sizeof(synthetic_ppi));
-      synthetic_ppi.hash = capture_line;
+      synthetic_ppi.hash = cap->orig_line;
       synthetic_ppi.plaintext = full_ntlm_hex;
       synthetic_ppi.index_filename = NULL;
       save_cracked_hash(&synthetic_ppi, HASH_NETNTLMV1);

--- a/docs/superpowers/specs/2026-08-11-ntlmv1-lookup-switch-design.md
+++ b/docs/superpowers/specs/2026-08-11-ntlmv1-lookup-switch-design.md
@@ -1,0 +1,164 @@
+# `-ntlmv1` end-to-end NetNTLMv1 cracking for `crackalack_lookup`
+
+## Origin
+
+GitLab issue #1 (gitrdun.trustedsec.net/justin.bollinger/rainbowcrackalack), filed by larry.spohn:
+today, cracking a captured NetNTLMv1 hash with rainbow tables requires running `crackalack_lookup`
+against block1/block2 by hand, then feeding the output potfile into `ntlmv1-multi` a second time to
+recover the full 16-byte NTLM hash. This spec adds a `-ntlmv1` switch that does the split, lookup, and
+reassembly in one pass.
+
+## CLI surface
+
+- New flag `-ntlmv1 <capture-or-file>` for `crackalack_lookup`, mutually exclusive with the existing
+  positional single-hash/hash-file argument — it replaces that argument:
+  `crackalack_lookup <rt_dir> -ntlmv1 <arg>`.
+- `<arg>` is tried as a file path first (existing `stat`-based file-vs-string detection, same pattern
+  already used for the positional argument). If it opens, every non-blank, non-`#`-prefixed line is
+  parsed as one capture (batch mode). Otherwise `<arg>` itself is parsed as a single capture line.
+- The existing `--challenge` flag is ignored in this mode — each capture line supplies its own
+  challenge.
+
+## Capture line format
+
+Standard NetNTLMv1 capture format: `user::domain:LMresp:NTresp:challenge`, split on `:` into exactly
+6 fields (`user`, workstation/blank, `domain`, `LMresp` = 48 hex chars, `NTresp` = 48 hex chars,
+`challenge` = 16 hex chars). Malformed lines are reported with a per-line error and skipped; the rest
+of a batch file continues processing.
+
+## ESS detection and handling
+
+NTLMv1 has two variants distinguishable from the capture itself:
+
+- **Classic NTLMv1**: `LMresp` is a legitimate 24-byte LM-style response. The 8-byte challenge that was
+  actually DES-encrypted is the raw server challenge field, used as-is.
+- **NTLMv1 with Extended Session Security (ESS / "NTLM2 Session")**: `LMresp` bytes 8–23 are zero
+  padding (bytes 0–7 hold an 8-byte client challenge). The value actually DES-encrypted is
+  `MD5(server_challenge || client_challenge)[0:8]`, where the client challenge is generated randomly
+  by the victim's OS on every authentication and is not attacker-controlled.
+
+**Detection heuristic**: `LMresp` bytes 8–23 all zero ⇒ ESS.
+
+**Why ESS can't use precomputed tables**: because the client challenge is random per-session, the
+effective encrypted challenge differs on every capture regardless of what server challenge is forced.
+A rainbow table is built for exactly one fixed challenge, so it can never match an ESS capture's
+effective challenge (this is independent of which challenge the table was built with, including the
+tool's default `1122334455667788`).
+
+**Behavior**: on ESS detection, short-circuit immediately with a distinct message —
+`"capture N: ESS/NTLM2-Session detected — client challenge is random per-session, precomputed tables cannot cover this, skipping"`
+— and move to the next capture (or exit cleanly if it was the only one). Do not attempt the
+challenge-matching step for ESS captures; the message must explain *why*, not report a generic
+mismatch.
+
+## Block split
+
+For non-ESS captures, split the 24-byte `NTresp` into three 8-byte DES ciphertext blocks:
+`block1 = NTresp[0:8]`, `block2 = NTresp[8:16]`, `block3 = NTresp[16:24]`. Hex-encode `block1`/`block2`
+as 16-hex-char strings — the exact format the existing pipeline already accepts as NetNTLMv1
+(`HASH_NETNTLMV1`) input.
+
+## Table-challenge matching
+
+Rainbow tables are challenge-specific (the challenge is encoded in the table filename), and the whole
+lookup run resolves a single global challenge from the loaded tables (existing logic,
+`crackalack_lookup.c:4395-4430`). Sequencing for `-ntlmv1` mode:
+
+1. Load config groups and resolve `g_challenge` from the loaded tables first (existing logic,
+   unmodified).
+2. Filter parsed captures: only those whose effective challenge equals the resolved `g_challenge` get
+   queued into `hashes[]`/`usernames[]` (both `block1_hex` and `block2_hex` per capture, same as
+   today's NetNTLMv1 batch-hash input). All other non-ESS mismatches are skipped with:
+   `"capture N: challenge <hex> doesn't match loaded tables' challenge <hex>, skipping"`.
+3. The existing precompute/GPU-CPU lookup/false-alarm-check pipeline runs completely unmodified on the
+   queued `block1_hex`/`block2_hex` entries.
+
+A side table (capture index → `{block1_hex, block2_hex, block3 raw bytes, effective_challenge, user,
+domain, nt_response_hex}`) is built during queuing and consulted in the post-lookup pass below. It is
+independent of the existing `usernames[]` array (which stays untouched, used only for display as
+today).
+
+## Post-lookup reassembly
+
+Hook point: immediately after `free_config_groups(&cg_head)` (`crackalack_lookup.c:4541`), before the
+final report banner. At this point `ppi_head` is fully populated with final cracked state and nothing
+has been freed yet.
+
+For each queued capture:
+
+1. `ppi_find(ppi_head, block1_hex)` and `ppi_find(ppi_head, block2_hex)`. If either has
+   `plaintext == NULL`, print a partial-failure line (which block wasn't found in tables) and move on
+   — no reassembly attempted.
+2. If both cracked: brute-force `block3`'s 2-byte key against `block3` ciphertext + effective
+   challenge. Loop all 65536 candidate 2-byte values, build each as a 7-byte plaintext key
+   (`{hi, lo, 0, 0, 0, 0, 0}`), run through the existing `setup_des_key()` /
+   `netntlmv1_hash()` (`cpu_rt_functions.c:443`, `:473`), compare ciphertext. Pure CPU, exhaustive, and
+   therefore cannot fail — treat a miss as an internal-error assertion (would indicate a decoding bug
+   elsewhere, not a real "not found" case).
+3. Assemble `key1(7 bytes) || key2(7 bytes) || key3(2 bytes)` = 16-byte NTLM hash, hex-encode (32
+   chars). Print:
+   `HASH CRACKED (NetNTLMv1, full NTLM hash) => user:domain:<32-hex NTLM hash>`.
+4. Append to the existing pot files via the existing `save_cracked_hash()` writer
+   (`crackalack_lookup.c:3790-3872`): build a synthetic `precomputed_and_potential_indices` with
+   `hash` = the capture's 48-hex `NTresp` string (a stable, unique identifier for this capture) and
+   `plaintext` = the recovered 32-hex NTLM hash, `index_filename = NULL` (skips the on-disk cache
+   unlink). This appends a normal-looking entry to both `rainbowcrackalack_jtr.pot` and
+   `rainbowcrackalack_hashcat.pot` with no new file or pot format.
+
+## New source files
+
+`netntlmv1_capture.c` / `netntlmv1_capture.h` (new, root of repo alongside other host `.c`/`.h` files):
+
+```c
+typedef struct {
+  char *user;
+  char *domain;
+  unsigned char lm_response[24];
+  unsigned char nt_response[24];
+  unsigned char server_challenge[8];
+  int is_ess;
+} netntlmv1_capture;
+
+int  netntlmv1_parse_capture_line(const char *line, netntlmv1_capture *out, char *errbuf, size_t errbuf_len);
+int  netntlmv1_capture_is_ess(const netntlmv1_capture *cap);              /* wraps the LMresp[8:24]==0 check */
+void netntlmv1_effective_challenge(const netntlmv1_capture *cap, unsigned char out[8]); /* classic only; caller must not call this for ESS captures */
+void netntlmv1_split_nt_response(const unsigned char nt_response[24],
+                                  unsigned char block1[8], unsigned char block2[8], unsigned char block3[8]);
+int  netntlmv1_bruteforce_block3(const unsigned char block3_ct[8], const unsigned char challenge[8],
+                                  unsigned char out_2bytes[2]); /* returns 0 on success; exhaustive, should never fail */
+void netntlmv1_assemble_ntlm_hash(const unsigned char key1[7], const unsigned char key2[7],
+                                   const unsigned char key3[2], unsigned char out_ntlm[16]);
+void netntlmv1_free_capture(netntlmv1_capture *cap);
+```
+
+`crackalack_lookup.c` changes:
+- argv parsing (`main()`, near `crackalack_lookup.c:4187-4234`): new `-ntlmv1 <arg>` flag, mutually
+  exclusive with the positional hash/file argument, sets a mode flag + stores the raw arg.
+- New static function to load/parse captures from `<arg>` (file-or-string detection, one
+  `netntlmv1_capture` per valid line), building the queued `hashes[]`/`usernames[]` arrays and the
+  capture side-table, deferred until after `g_challenge` is resolved from loaded tables.
+- New static function for the post-lookup reassembly pass described above, called once at the hook
+  point.
+- `print_usage_and_exit()` gets a `-ntlmv1` usage line.
+
+## Testing
+
+- `tests/test_netntlmv1_capture.c` (new), covering:
+  - Valid capture line parsing (classic and ESS).
+  - Malformed lines (wrong field count, bad hex length) rejected with an error, not a crash.
+  - ESS detection: LMresp with zero padding at [8:24] → ESS; a full-entropy LMresp → classic.
+  - Block split correctness against a known 24-byte NTresp.
+  - Block3 brute-force round-trip: pick a known 7-byte key, compute its DES ciphertext via
+    `netntlmv1_hash()`, confirm `netntlmv1_bruteforce_block3()` recovers the same 2 trailing bytes.
+  - Full assembly: known key1/key2/key3 → expected 16-byte NTLM hash.
+- One end-to-end test (extends existing NetNTLMv1 test harness): generate tiny NetNTLMv1 tables for a
+  known challenge + known plaintext, synthesize a capture line whose NT response is the DES encoding
+  of that plaintext's derived hash under that challenge, run `-ntlmv1` against it, confirm the
+  reassembled 32-hex NTLM hash matches the known plaintext's real NTLM hash.
+
+## Out of scope
+
+- Batch captures with heterogeneous challenges beyond filtering (no multi-challenge/multi-table-set
+  run in one invocation — matches the existing single-global-challenge architecture).
+- Automatically chaining into an NTLM-table lookup pass for the recovered hash (user runs that
+  separately if desired).

--- a/docs/superpowers/specs/2026-08-11-ntlmv1-lookup-switch-design.md
+++ b/docs/superpowers/specs/2026-08-11-ntlmv1-lookup-switch-design.md
@@ -37,7 +37,7 @@ NTLMv1 has two variants distinguishable from the capture itself:
   `MD5(server_challenge || client_challenge)[0:8]`, where the client challenge is generated randomly
   by the victim's OS on every authentication and is not attacker-controlled.
 
-**Detection heuristic**: `LMresp` bytes 8–23 all zero ⇒ ESS.
+**Detection heuristic**: `LMresp` bytes 8–23 all zero AND bytes 0–7 nonzero ⇒ ESS. An all-zero 24-byte LM response (both ranges zero) is treated as classic/non-ESS, since it's more likely a legitimate "no LM response sent" classic capture than a true ESS capture whose randomly-generated 8-byte client challenge happened to be all zero.
 
 **Why ESS can't use precomputed tables**: because the client challenge is random per-session, the
 effective encrypted challenge differs on every capture regardless of what server challenge is forced.

--- a/docs/superpowers/specs/2026-08-11-ntlmv1-lookup-switch-design.md
+++ b/docs/superpowers/specs/2026-08-11-ntlmv1-lookup-switch-design.md
@@ -100,10 +100,15 @@ For each queued capture:
    `HASH CRACKED (NetNTLMv1, full NTLM hash) => user:domain:<32-hex NTLM hash>`.
 4. Append to the existing pot files via the existing `save_cracked_hash()` writer
    (`crackalack_lookup.c:3790-3872`): build a synthetic `precomputed_and_potential_indices` with
-   `hash` = the capture's 48-hex `NTresp` string (a stable, unique identifier for this capture) and
-   `plaintext` = the recovered 32-hex NTLM hash, `index_filename = NULL` (skips the on-disk cache
-   unlink). This appends a normal-looking entry to both `rainbowcrackalack_jtr.pot` and
-   `rainbowcrackalack_hashcat.pot` with no new file or pot format.
+   `hash` = the **full original capture line** (`user::domain:LMresp:NTresp:challenge`, i.e. exactly
+   what you'd feed hashcat `-m 5500`) and `plaintext` = the recovered 32-hex NTLM hash,
+   `index_filename = NULL` (skips the on-disk cache unlink). Call `save_cracked_hash()` with
+   `hash_type = HASH_NETNTLMV1` (not `HASH_NTLM`) so the JTR writer does *not* prepend `$NT$` — that
+   prefix means "this hash field is an NT hash," which would be wrong here since the hash field is a
+   full NetNTLMv1 capture line, not an NT hash. The resulting pot line matches real hashcat `-m 5500`
+   pot syntax (`<capture line>:<cracked value>`), just with an NTLM hash in the crack-value slot
+   instead of a human password — a real hashcat run against that same capture line with `-m 5500`
+   would recognize it as already-cracked and display the NTLM hash in place of a password.
 
 ## New source files
 

--- a/netntlmv1_capture.c
+++ b/netntlmv1_capture.c
@@ -145,6 +145,13 @@ int netntlmv1_parse_capture_line(const char *line, netntlmv1_capture *out, char 
     return -1;
   }
 
+  out->orig_line = strdup(line_copy);
+  if (out->orig_line == NULL) {
+    snprintf(errbuf, errbuf_len, "out of memory");
+    free(line_copy);
+    return -1;
+  }
+
   field_idx = 0;
   field_start = line_copy;
   for (i = 0; i <= linelen; i++) {
@@ -158,32 +165,44 @@ int netntlmv1_parse_capture_line(const char *line, netntlmv1_capture *out, char 
   if (strlen(fields[3]) != 48) {
     snprintf(errbuf, errbuf_len, "LM response must be 48 hex chars, got %zu", strlen(fields[3]));
     free(line_copy);
+    free(out->orig_line);
+    out->orig_line = NULL;
     return -1;
   }
   if (strlen(fields[4]) != 48) {
     snprintf(errbuf, errbuf_len, "NT response must be 48 hex chars, got %zu", strlen(fields[4]));
     free(line_copy);
+    free(out->orig_line);
+    out->orig_line = NULL;
     return -1;
   }
   if (strlen(fields[5]) != 16) {
     snprintf(errbuf, errbuf_len, "challenge must be 16 hex chars, got %zu", strlen(fields[5]));
     free(line_copy);
+    free(out->orig_line);
+    out->orig_line = NULL;
     return -1;
   }
 
   if (netntlmv1_hex_decode(fields[3], 48, out->lm_response) != 0) {
     snprintf(errbuf, errbuf_len, "LM response contains invalid hex");
     free(line_copy);
+    free(out->orig_line);
+    out->orig_line = NULL;
     return -1;
   }
   if (netntlmv1_hex_decode(fields[4], 48, out->nt_response) != 0) {
     snprintf(errbuf, errbuf_len, "NT response contains invalid hex");
     free(line_copy);
+    free(out->orig_line);
+    out->orig_line = NULL;
     return -1;
   }
   if (netntlmv1_hex_decode(fields[5], 16, out->server_challenge) != 0) {
     snprintf(errbuf, errbuf_len, "challenge contains invalid hex");
     free(line_copy);
+    free(out->orig_line);
+    out->orig_line = NULL;
     return -1;
   }
 
@@ -201,6 +220,8 @@ void netntlmv1_free_capture(netntlmv1_capture *cap) {
 
   free(cap->user);
   free(cap->domain);
+  free(cap->orig_line);
   cap->user = NULL;
   cap->domain = NULL;
+  cap->orig_line = NULL;
 }

--- a/netntlmv1_capture.c
+++ b/netntlmv1_capture.c
@@ -1,0 +1,206 @@
+/*
+ * Rainbow Crackalack: netntlmv1_capture.c
+ *
+ * Parses full NetNTLMv1 captures (user::domain:LMresp:NTresp:challenge),
+ * detects ESS/NTLM2-Session, splits the NT response into its three DES
+ * blocks, brute-forces the 2-byte block3 key, and reassembles a full
+ * 16-byte NTLM hash from three recovered blocks.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "cpu_rt_functions.h"
+#include "netntlmv1_capture.h"
+
+static int hexval(char c) {
+  if (c >= '0' && c <= '9') return c - '0';
+  if (c >= 'a' && c <= 'f') return c - 'a' + 10;
+  if (c >= 'A' && c <= 'F') return c - 'A' + 10;
+  return -1;
+}
+
+int netntlmv1_hex_decode(const char *hex, size_t hexlen, unsigned char *out) {
+  size_t i;
+
+  if (hexlen % 2 != 0)
+    return -1;
+
+  for (i = 0; i < hexlen / 2; i++) {
+    int hi = hexval(hex[i * 2]);
+    int lo = hexval(hex[i * 2 + 1]);
+
+    if (hi < 0 || lo < 0)
+      return -1;
+
+    out[i] = (unsigned char)((hi << 4) | lo);
+  }
+
+  return 0;
+}
+
+void netntlmv1_hex_encode(const unsigned char *in, size_t inlen, char *out) {
+  static const char hexchars[] = "0123456789abcdef";
+  size_t i;
+
+  for (i = 0; i < inlen; i++) {
+    out[i * 2]     = hexchars[(in[i] >> 4) & 0x0F];
+    out[i * 2 + 1] = hexchars[in[i] & 0x0F];
+  }
+  out[inlen * 2] = '\0';
+}
+
+int netntlmv1_capture_is_ess(const netntlmv1_capture *cap) {
+  int i;
+
+  for (i = 8; i < 24; i++) {
+    if (cap->lm_response[i] != 0x00)
+      return 0;
+  }
+
+  for (i = 0; i < 8; i++) {
+    if (cap->lm_response[i] != 0x00)
+      return 1;
+  }
+
+  return 0;
+}
+
+void netntlmv1_effective_challenge(const netntlmv1_capture *cap, unsigned char out[8]) {
+  memcpy(out, cap->server_challenge, 8);
+}
+
+void netntlmv1_split_nt_response(const unsigned char nt_response[24],
+                                  unsigned char block1[8], unsigned char block2[8], unsigned char block3[8]) {
+  memcpy(block1, nt_response, 8);
+  memcpy(block2, nt_response + 8, 8);
+  memcpy(block3, nt_response + 16, 8);
+}
+
+int netntlmv1_bruteforce_block3(const unsigned char block3_ct[8], const unsigned char challenge[8], unsigned char out_2bytes[2]) {
+  unsigned int hi, lo;
+
+  set_netntlmv1_challenge(challenge);
+
+  for (hi = 0; hi <= 0xFF; hi++) {
+    for (lo = 0; lo <= 0xFF; lo++) {
+      char key_56[7];
+      unsigned char des_key[8], candidate_hash[8];
+
+      key_56[0] = (char)hi;
+      key_56[1] = (char)lo;
+      key_56[2] = 0; key_56[3] = 0; key_56[4] = 0; key_56[5] = 0; key_56[6] = 0;
+
+      setup_des_key(key_56, des_key);
+      netntlmv1_hash(des_key, 8, candidate_hash);
+
+      if (memcmp(candidate_hash, block3_ct, 8) == 0) {
+        out_2bytes[0] = (unsigned char)hi;
+        out_2bytes[1] = (unsigned char)lo;
+        return 0;
+      }
+    }
+  }
+
+  return -1;
+}
+
+void netntlmv1_assemble_ntlm_hash(const unsigned char key1[7], const unsigned char key2[7],
+                                   const unsigned char key3[2], unsigned char out_ntlm[16]) {
+  memcpy(out_ntlm, key1, 7);
+  memcpy(out_ntlm + 7, key2, 7);
+  memcpy(out_ntlm + 14, key3, 2);
+}
+
+int netntlmv1_parse_capture_line(const char *line, netntlmv1_capture *out, char *errbuf, size_t errbuf_len) {
+  char *line_copy = NULL;
+  char *fields[6] = {0};
+  size_t linelen;
+  int colon_count = 0;
+  int field_idx;
+  char *field_start;
+  size_t i;
+
+  memset(out, 0, sizeof(*out));
+
+  line_copy = strdup(line);
+  if (line_copy == NULL) {
+    snprintf(errbuf, errbuf_len, "out of memory");
+    return -1;
+  }
+
+  linelen = strlen(line_copy);
+  while (linelen > 0 && (line_copy[linelen - 1] == '\n' || line_copy[linelen - 1] == '\r'))
+    line_copy[--linelen] = '\0';
+
+  for (i = 0; i < linelen; i++) {
+    if (line_copy[i] == ':')
+      colon_count++;
+  }
+
+  if (colon_count != 5) {
+    snprintf(errbuf, errbuf_len, "expected 6 colon-separated fields (user::domain:LM:NT:challenge), got %d colon(s)", colon_count);
+    free(line_copy);
+    return -1;
+  }
+
+  field_idx = 0;
+  field_start = line_copy;
+  for (i = 0; i <= linelen; i++) {
+    if (i == linelen || line_copy[i] == ':') {
+      line_copy[i] = '\0';
+      fields[field_idx++] = field_start;
+      field_start = line_copy + i + 1;
+    }
+  }
+
+  if (strlen(fields[3]) != 48) {
+    snprintf(errbuf, errbuf_len, "LM response must be 48 hex chars, got %zu", strlen(fields[3]));
+    free(line_copy);
+    return -1;
+  }
+  if (strlen(fields[4]) != 48) {
+    snprintf(errbuf, errbuf_len, "NT response must be 48 hex chars, got %zu", strlen(fields[4]));
+    free(line_copy);
+    return -1;
+  }
+  if (strlen(fields[5]) != 16) {
+    snprintf(errbuf, errbuf_len, "challenge must be 16 hex chars, got %zu", strlen(fields[5]));
+    free(line_copy);
+    return -1;
+  }
+
+  if (netntlmv1_hex_decode(fields[3], 48, out->lm_response) != 0) {
+    snprintf(errbuf, errbuf_len, "LM response contains invalid hex");
+    free(line_copy);
+    return -1;
+  }
+  if (netntlmv1_hex_decode(fields[4], 48, out->nt_response) != 0) {
+    snprintf(errbuf, errbuf_len, "NT response contains invalid hex");
+    free(line_copy);
+    return -1;
+  }
+  if (netntlmv1_hex_decode(fields[5], 16, out->server_challenge) != 0) {
+    snprintf(errbuf, errbuf_len, "challenge contains invalid hex");
+    free(line_copy);
+    return -1;
+  }
+
+  out->user = strdup(fields[0]);
+  out->domain = strdup(fields[2]);
+  out->is_ess = netntlmv1_capture_is_ess(out);
+
+  free(line_copy);
+  return 0;
+}
+
+void netntlmv1_free_capture(netntlmv1_capture *cap) {
+  if (cap == NULL)
+    return;
+
+  free(cap->user);
+  free(cap->domain);
+  cap->user = NULL;
+  cap->domain = NULL;
+}

--- a/netntlmv1_capture.h
+++ b/netntlmv1_capture.h
@@ -18,8 +18,13 @@ typedef struct {
  * failure, writes a human-readable reason into errbuf and returns -1. */
 int netntlmv1_parse_capture_line(const char *line, netntlmv1_capture *out, char *errbuf, size_t errbuf_len);
 
-/* True if lm_response[8..23] are all zero -- the ESS/NTLM2-Session padding
- * pattern (the real 8-byte client challenge occupies lm_response[0..7]). */
+/* Returns 1 if lm_response[8..23] are all zero AND lm_response[0..7] are
+ * nonzero -- the ESS/NTLM2-Session padding pattern (the real 8-byte client
+ * challenge occupies lm_response[0..7]). An all-zero 24-byte LM response (both
+ * ranges zero) is treated as classic/non-ESS on the theory that it's more
+ * likely a legitimate "no LM response sent" classic capture than a true ESS
+ * capture whose randomly-generated 8-byte client challenge happened to be all
+ * zero. */
 int netntlmv1_capture_is_ess(const netntlmv1_capture *cap);
 
 /* Classic NTLMv1 only: the effective challenge is the raw server challenge.
@@ -35,7 +40,12 @@ void netntlmv1_split_nt_response(const unsigned char nt_response[24],
  * with 5 zero bytes) for the one whose DES encryption of `challenge` equals
  * block3_ct.  Returns 0 and fills out_2bytes on success.  This is a
  * complete keyspace, so a nonzero return indicates an internal bug (e.g. a
- * blocks/challenge mismatch), not a normal "not found" case. */
+ * blocks/challenge mismatch), not a normal "not found" case.
+ *
+ * NOTE: This function mutates the process-wide NetNTLMv1 challenge as a side
+ * effect (via set_netntlmv1_challenge()). Callers must not rely on any
+ * previously-set global challenge surviving this call and must re-set it
+ * afterward if needed. */
 int netntlmv1_bruteforce_block3(const unsigned char block3_ct[8], const unsigned char challenge[8], unsigned char out_2bytes[2]);
 
 /* key1/key2 are the two 7-byte DES keys recovered from the rainbow tables

--- a/netntlmv1_capture.h
+++ b/netntlmv1_capture.h
@@ -10,12 +10,14 @@ typedef struct {
   unsigned char nt_response[24];
   unsigned char server_challenge[8];
   int is_ess;
+  char *orig_line; /* verbatim, trimmed (CR/LF stripped) original capture line, for pot-file entries */
 } netntlmv1_capture;
 
 /* Parses "user::domain:LMresp:NTresp:challenge" (LMresp/NTresp = 48 hex
  * chars, challenge = 16 hex chars).  On success, fills *out (caller must
- * eventually call netntlmv1_free_capture()) and sets out->is_ess.  On
- * failure, writes a human-readable reason into errbuf and returns -1. */
+ * eventually call netntlmv1_free_capture()), sets out->is_ess, and stores
+ * the verbatim trimmed input line in out->orig_line.  On failure, writes a
+ * human-readable reason into errbuf and returns -1. */
 int netntlmv1_parse_capture_line(const char *line, netntlmv1_capture *out, char *errbuf, size_t errbuf_len);
 
 /* Returns 1 if lm_response[8..23] are all zero AND lm_response[0..7] are

--- a/netntlmv1_capture.h
+++ b/netntlmv1_capture.h
@@ -1,0 +1,56 @@
+#ifndef _NETNTLMV1_CAPTURE_H
+#define _NETNTLMV1_CAPTURE_H
+
+#include <stddef.h>
+
+typedef struct {
+  char *user;
+  char *domain;
+  unsigned char lm_response[24];
+  unsigned char nt_response[24];
+  unsigned char server_challenge[8];
+  int is_ess;
+} netntlmv1_capture;
+
+/* Parses "user::domain:LMresp:NTresp:challenge" (LMresp/NTresp = 48 hex
+ * chars, challenge = 16 hex chars).  On success, fills *out (caller must
+ * eventually call netntlmv1_free_capture()) and sets out->is_ess.  On
+ * failure, writes a human-readable reason into errbuf and returns -1. */
+int netntlmv1_parse_capture_line(const char *line, netntlmv1_capture *out, char *errbuf, size_t errbuf_len);
+
+/* True if lm_response[8..23] are all zero -- the ESS/NTLM2-Session padding
+ * pattern (the real 8-byte client challenge occupies lm_response[0..7]). */
+int netntlmv1_capture_is_ess(const netntlmv1_capture *cap);
+
+/* Classic NTLMv1 only: the effective challenge is the raw server challenge.
+ * Callers must not call this for an ESS capture (cap->is_ess == 1) -- ESS's
+ * effective challenge depends on a random per-session client challenge that
+ * defeats precomputed tables regardless of how it's derived. */
+void netntlmv1_effective_challenge(const netntlmv1_capture *cap, unsigned char out[8]);
+
+void netntlmv1_split_nt_response(const unsigned char nt_response[24],
+                                  unsigned char block1[8], unsigned char block2[8], unsigned char block3[8]);
+
+/* Exhaustively searches all 65536 2-byte keys (padded to a 7-byte DES key
+ * with 5 zero bytes) for the one whose DES encryption of `challenge` equals
+ * block3_ct.  Returns 0 and fills out_2bytes on success.  This is a
+ * complete keyspace, so a nonzero return indicates an internal bug (e.g. a
+ * blocks/challenge mismatch), not a normal "not found" case. */
+int netntlmv1_bruteforce_block3(const unsigned char block3_ct[8], const unsigned char challenge[8], unsigned char out_2bytes[2]);
+
+/* key1/key2 are the two 7-byte DES keys recovered from the rainbow tables
+ * (bytes 0-6 and 7-13 of the target NTLM hash); key3 is the 2 recovered
+ * bytes (bytes 14-15).  out_ntlm receives the reassembled 16-byte hash. */
+void netntlmv1_assemble_ntlm_hash(const unsigned char key1[7], const unsigned char key2[7],
+                                   const unsigned char key3[2], unsigned char out_ntlm[16]);
+
+void netntlmv1_free_capture(netntlmv1_capture *cap);
+
+/* out must be at least inlen*2+1 bytes.  Lowercase hex, NUL-terminated. */
+void netntlmv1_hex_encode(const unsigned char *in, size_t inlen, char *out);
+
+/* Decodes exactly hexlen hex chars (hexlen must be even) into hexlen/2
+ * bytes at out.  Returns 0 on success, -1 on odd length or invalid hex. */
+int netntlmv1_hex_decode(const char *hex, size_t hexlen, unsigned char *out);
+
+#endif /* _NETNTLMV1_CAPTURE_H */

--- a/tests/cpu_tests_common.c
+++ b/tests/cpu_tests_common.c
@@ -12,6 +12,7 @@
 #include "cpu_tests_common.h"
 #include "test_challenge_host.h"
 #include "test_misc.h"
+#include "test_netntlmv1_capture.h"
 #include "test_bloom.h"
 #include "test_sort.h"
 #include "test_decompress.h"
@@ -49,6 +50,14 @@ int run_cpu_only_tests(void) {
   /* Misc tests (CPU-only, no kernel needed). */
   printf("Running misc tests... "); fflush(stdout);
   if (!test_misc()) {
+    all_passed = 0;
+    PRINT_FAILED();
+  } else
+    PRINT_PASSED();
+
+  /* NetNTLMv1 capture tests (CPU-only, no kernel needed). */
+  printf("Running NetNTLMv1 capture tests... "); fflush(stdout);
+  if (!test_netntlmv1_capture()) {
     all_passed = 0;
     PRINT_FAILED();
   } else

--- a/tests/test_netntlmv1_capture.c
+++ b/tests/test_netntlmv1_capture.c
@@ -219,6 +219,52 @@ static int group_g(void)
   return ok;
 }
 
+/* --- Group H: orig_line is preserved verbatim (uppercase hex, workstation
+ * field, trailing CRLF stripped) for pot-file reconstruction. --- */
+static int group_h(void)
+{
+  int ok = 1;
+  netntlmv1_capture cap;
+  char errbuf[256];
+  const char *trimmed =
+    "testuser:WKSTN01:TESTDOMAIN:"
+    "000000000000000000000000000000000000000000000000:"
+    "AAAAAAAAAAAAAAAAaaaaaaaaaaaaaaaaAAAAAAAAAAAAAAAA:"
+    "1122334455667788";
+  char line_with_crlf[512];
+
+  /* CAP-15: orig_line matches the input exactly, verbatim, including the
+   * uppercase hex and the non-empty workstation field. */
+  if (netntlmv1_parse_capture_line(trimmed, &cap, errbuf, sizeof(errbuf)) != 0) {
+    fprintf(stderr, "CAP-15 failed: %s\n", errbuf);
+    ok = 0;
+  } else {
+    if (cap.orig_line == NULL || strcmp(cap.orig_line, trimmed) != 0) {
+      fprintf(stderr, "CAP-15 failed: orig_line=\"%s\", expected \"%s\"\n",
+              cap.orig_line ? cap.orig_line : "(null)", trimmed);
+      ok = 0;
+    }
+    netntlmv1_free_capture(&cap);
+  }
+
+  /* CAP-16: trailing CRLF is stripped from orig_line, but the rest of the
+   * line is otherwise untouched. */
+  snprintf(line_with_crlf, sizeof(line_with_crlf), "%s\r\n", trimmed);
+  if (netntlmv1_parse_capture_line(line_with_crlf, &cap, errbuf, sizeof(errbuf)) != 0) {
+    fprintf(stderr, "CAP-16 failed: %s\n", errbuf);
+    ok = 0;
+  } else {
+    if (cap.orig_line == NULL || strcmp(cap.orig_line, trimmed) != 0) {
+      fprintf(stderr, "CAP-16 failed: orig_line=\"%s\", expected \"%s\"\n",
+              cap.orig_line ? cap.orig_line : "(null)", trimmed);
+      ok = 0;
+    }
+    netntlmv1_free_capture(&cap);
+  }
+
+  return ok;
+}
+
 int test_netntlmv1_capture(void)
 {
   int ok = 1;
@@ -230,6 +276,7 @@ int test_netntlmv1_capture(void)
   if (!group_e()) ok = 0;
   if (!group_f()) ok = 0;
   if (!group_g()) ok = 0;
+  if (!group_h()) ok = 0;
 
   return ok;
 }

--- a/tests/test_netntlmv1_capture.c
+++ b/tests/test_netntlmv1_capture.c
@@ -36,13 +36,14 @@ static int group_b(void)
   int ok = 1;
   netntlmv1_capture cap;
   char errbuf[256];
-  /* 48 zero hex chars = classic (non-ESS) LM response; 48 'a' hex chars as
-   * an arbitrary NT response; 16 '1' hex chars as the challenge. */
-  const char *classic_line =
+  /* 48 zero hex chars = the ambiguous all-zero LM response case, resolved as
+   * classic (non-ESS) per the tie-break heuristic; 48 'a' hex chars as an
+   * arbitrary NT response; 16 '1' hex chars as the challenge. */
+  const char *classic_line_all_zero =
     "alice::CORP:000000000000000000000000000000000000000000000000:"
     "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:1111111111111111";
 
-  if (netntlmv1_parse_capture_line(classic_line, &cap, errbuf, sizeof(errbuf)) != 0) {
+  if (netntlmv1_parse_capture_line(classic_line_all_zero, &cap, errbuf, sizeof(errbuf)) != 0) {
     fprintf(stderr, "CAP-01 failed: %s\n", errbuf);
     ok = 0;
   } else {
@@ -51,6 +52,24 @@ static int group_b(void)
     if (cap.nt_response[0] != 0xaa) { fprintf(stderr, "CAP-04 failed: nt_response[0]=%02x\n", cap.nt_response[0]); ok = 0; }
     if (cap.server_challenge[0] != 0x11) { fprintf(stderr, "CAP-05 failed: challenge[0]=%02x\n", cap.server_challenge[0]); ok = 0; }
     if (cap.is_ess != 0) { fprintf(stderr, "CAP-06 failed: expected classic (is_ess=0), got %d\n", cap.is_ess); ok = 0; }
+    netntlmv1_free_capture(&cap);
+  }
+
+  /* Realistic classic NTLMv1: LM response with nonzero bytes across the
+   * entire 24-byte field (not the ambiguous all-zero case). */
+  const char *classic_line_realistic =
+    "bob::CORP:aaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbcccccccccccccccc:"
+    "dddddddddddddddddddddddddddddddddddddddddddddddd:2222222222222222";
+
+  if (netntlmv1_parse_capture_line(classic_line_realistic, &cap, errbuf, sizeof(errbuf)) != 0) {
+    fprintf(stderr, "CAP-09 failed: %s\n", errbuf);
+    ok = 0;
+  } else {
+    if (strcmp(cap.user, "bob") != 0) { fprintf(stderr, "CAP-10 failed: user=\"%s\"\n", cap.user); ok = 0; }
+    if (cap.lm_response[0] != 0xaa) { fprintf(stderr, "CAP-11 failed: lm_response[0]=%02x\n", cap.lm_response[0]); ok = 0; }
+    if (cap.lm_response[8] != 0xbb) { fprintf(stderr, "CAP-12 failed: lm_response[8]=%02x\n", cap.lm_response[8]); ok = 0; }
+    if (cap.lm_response[16] != 0xcc) { fprintf(stderr, "CAP-13 failed: lm_response[16]=%02x\n", cap.lm_response[16]); ok = 0; }
+    if (cap.is_ess != 0) { fprintf(stderr, "CAP-14 failed: expected classic (is_ess=0), got %d\n", cap.is_ess); ok = 0; }
     netntlmv1_free_capture(&cap);
   }
 
@@ -163,6 +182,40 @@ static int group_f(void)
     }
   }
 
+  /* Reset the global challenge to a known default (all-zero) to avoid
+   * leaving stale state for subsequent test groups. netntlmv1_bruteforce_block3
+   * mutates the global challenge as a side effect. */
+  {
+    unsigned char default_challenge[8] = { 0, 0, 0, 0, 0, 0, 0, 0 };
+    set_netntlmv1_challenge(default_challenge);
+  }
+
+  return ok;
+}
+
+/* --- Group G: effective challenge --- */
+static int group_g(void)
+{
+  int ok = 1;
+  netntlmv1_capture cap;
+  char errbuf[256];
+  unsigned char out_challenge[8];
+  const char *classic_line =
+    "alice::CORP:000000000000000000000000000000000000000000000000:"
+    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:1111111111111111";
+
+  if (netntlmv1_parse_capture_line(classic_line, &cap, errbuf, sizeof(errbuf)) != 0) {
+    fprintf(stderr, "EFFCH-01 failed: %s\n", errbuf);
+    ok = 0;
+  } else {
+    netntlmv1_effective_challenge(&cap, out_challenge);
+    if (memcmp(out_challenge, cap.server_challenge, 8) != 0) {
+      fprintf(stderr, "EFFCH-02 failed: effective challenge did not match server_challenge\n");
+      ok = 0;
+    }
+    netntlmv1_free_capture(&cap);
+  }
+
   return ok;
 }
 
@@ -176,6 +229,7 @@ int test_netntlmv1_capture(void)
   if (!group_d()) ok = 0;
   if (!group_e()) ok = 0;
   if (!group_f()) ok = 0;
+  if (!group_g()) ok = 0;
 
   return ok;
 }

--- a/tests/test_netntlmv1_capture.c
+++ b/tests/test_netntlmv1_capture.c
@@ -1,0 +1,181 @@
+/*
+ * Rainbow Crackalack: test_netntlmv1_capture.c
+ * CPU-only tests for netntlmv1_capture.c.
+ */
+
+#include <stdio.h>
+#include <string.h>
+
+#include "cpu_rt_functions.h"
+#include "netntlmv1_capture.h"
+#include "test_netntlmv1_capture.h"
+
+/* --- Group A: hex encode/decode --- */
+static int group_a(void)
+{
+  int ok = 1;
+  unsigned char bytes[4] = { 0xDE, 0xAD, 0xBE, 0xEF };
+  char hex[9] = {0};
+  unsigned char decoded[4] = {0};
+
+  netntlmv1_hex_encode(bytes, 4, hex);
+  if (strcmp(hex, "deadbeef") != 0) { fprintf(stderr, "HEX-01 failed: got \"%s\"\n", hex); ok = 0; }
+
+  if (netntlmv1_hex_decode("deadbeef", 8, decoded) != 0) { fprintf(stderr, "HEX-02 failed: decode returned error\n"); ok = 0; }
+  if (memcmp(decoded, bytes, 4) != 0) { fprintf(stderr, "HEX-03 failed: round-trip mismatch\n"); ok = 0; }
+
+  if (netntlmv1_hex_decode("abc", 3, decoded) == 0) { fprintf(stderr, "HEX-04 failed: odd length should be rejected\n"); ok = 0; }
+  if (netntlmv1_hex_decode("zzzz", 4, decoded) == 0) { fprintf(stderr, "HEX-05 failed: invalid hex should be rejected\n"); ok = 0; }
+
+  return ok;
+}
+
+/* --- Group B: capture line parsing --- */
+static int group_b(void)
+{
+  int ok = 1;
+  netntlmv1_capture cap;
+  char errbuf[256];
+  /* 48 zero hex chars = classic (non-ESS) LM response; 48 'a' hex chars as
+   * an arbitrary NT response; 16 '1' hex chars as the challenge. */
+  const char *classic_line =
+    "alice::CORP:000000000000000000000000000000000000000000000000:"
+    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:1111111111111111";
+
+  if (netntlmv1_parse_capture_line(classic_line, &cap, errbuf, sizeof(errbuf)) != 0) {
+    fprintf(stderr, "CAP-01 failed: %s\n", errbuf);
+    ok = 0;
+  } else {
+    if (strcmp(cap.user, "alice") != 0) { fprintf(stderr, "CAP-02 failed: user=\"%s\"\n", cap.user); ok = 0; }
+    if (strcmp(cap.domain, "CORP") != 0) { fprintf(stderr, "CAP-03 failed: domain=\"%s\"\n", cap.domain); ok = 0; }
+    if (cap.nt_response[0] != 0xaa) { fprintf(stderr, "CAP-04 failed: nt_response[0]=%02x\n", cap.nt_response[0]); ok = 0; }
+    if (cap.server_challenge[0] != 0x11) { fprintf(stderr, "CAP-05 failed: challenge[0]=%02x\n", cap.server_challenge[0]); ok = 0; }
+    if (cap.is_ess != 0) { fprintf(stderr, "CAP-06 failed: expected classic (is_ess=0), got %d\n", cap.is_ess); ok = 0; }
+    netntlmv1_free_capture(&cap);
+  }
+
+  /* Malformed: wrong field count. */
+  if (netntlmv1_parse_capture_line("alice::CORP:deadbeef", &cap, errbuf, sizeof(errbuf)) == 0) {
+    fprintf(stderr, "CAP-07 failed: malformed line should have been rejected\n");
+    ok = 0;
+  }
+
+  /* Malformed: LM response wrong length. */
+  {
+    const char *bad_line = "alice::CORP:deadbeef:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:1111111111111111";
+    if (netntlmv1_parse_capture_line(bad_line, &cap, errbuf, sizeof(errbuf)) == 0) {
+      fprintf(stderr, "CAP-08 failed: short LM response should have been rejected\n");
+      ok = 0;
+    }
+  }
+
+  return ok;
+}
+
+/* --- Group C: ESS detection --- */
+static int group_c(void)
+{
+  int ok = 1;
+  netntlmv1_capture cap;
+  char errbuf[256];
+  /* LM response = 8 bytes of client challenge (nonzero) + 16 zero bytes:
+   * "aaaaaaaaaaaaaaaa" (16 hex = 8 bytes, nonzero) followed by 32 zero hex
+   * chars (16 zero bytes) = the ESS padding pattern. */
+  const char *ess_line =
+    "bob::CORP:aaaaaaaaaaaaaaaa00000000000000000000000000000000:"
+    "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb:2222222222222222";
+
+  if (netntlmv1_parse_capture_line(ess_line, &cap, errbuf, sizeof(errbuf)) != 0) {
+    fprintf(stderr, "ESS-01 failed: %s\n", errbuf);
+    ok = 0;
+  } else {
+    if (cap.is_ess != 1) { fprintf(stderr, "ESS-02 failed: expected is_ess=1, got %d\n", cap.is_ess); ok = 0; }
+    if (!netntlmv1_capture_is_ess(&cap)) { fprintf(stderr, "ESS-03 failed: netntlmv1_capture_is_ess disagreed\n"); ok = 0; }
+    netntlmv1_free_capture(&cap);
+  }
+
+  return ok;
+}
+
+/* --- Group D: block split --- */
+static int group_d(void)
+{
+  int ok = 1;
+  unsigned char nt_response[24];
+  unsigned char block1[8], block2[8], block3[8];
+  int i;
+
+  for (i = 0; i < 24; i++)
+    nt_response[i] = (unsigned char)i;
+
+  netntlmv1_split_nt_response(nt_response, block1, block2, block3);
+
+  for (i = 0; i < 8; i++) {
+    if (block1[i] != (unsigned char)i)      { fprintf(stderr, "SPLIT-01 failed at %d\n", i); ok = 0; }
+    if (block2[i] != (unsigned char)(i + 8)) { fprintf(stderr, "SPLIT-02 failed at %d\n", i); ok = 0; }
+    if (block3[i] != (unsigned char)(i + 16)) { fprintf(stderr, "SPLIT-03 failed at %d\n", i); ok = 0; }
+  }
+
+  return ok;
+}
+
+/* --- Group E: hash assembly --- */
+static int group_e(void)
+{
+  int ok = 1;
+  unsigned char key1[7], key2[7], key3[2], out_ntlm[16];
+  unsigned char expected[16];
+  int i;
+
+  for (i = 0; i < 7; i++) { key1[i] = (unsigned char)(0x10 + i); key2[i] = (unsigned char)(0x20 + i); }
+  key3[0] = 0x30; key3[1] = 0x31;
+
+  memcpy(expected, key1, 7);
+  memcpy(expected + 7, key2, 7);
+  memcpy(expected + 14, key3, 2);
+
+  netntlmv1_assemble_ntlm_hash(key1, key2, key3, out_ntlm);
+
+  if (memcmp(out_ntlm, expected, 16) != 0) { fprintf(stderr, "ASM-01 failed\n"); ok = 0; }
+
+  return ok;
+}
+
+/* --- Group F: block3 brute force round-trip --- */
+static int group_f(void)
+{
+  int ok = 1;
+  unsigned char challenge[8] = { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08 };
+  char key_56[7] = { 0x12, 0x34, 0, 0, 0, 0, 0 };
+  unsigned char des_key[8], ciphertext[8], recovered[2];
+
+  set_netntlmv1_challenge(challenge);
+  setup_des_key(key_56, des_key);
+  netntlmv1_hash(des_key, 8, ciphertext);
+
+  if (netntlmv1_bruteforce_block3(ciphertext, challenge, recovered) != 0) {
+    fprintf(stderr, "BF3-01 failed: brute force returned error\n");
+    ok = 0;
+  } else {
+    if (recovered[0] != 0x12 || recovered[1] != 0x34) {
+      fprintf(stderr, "BF3-02 failed: got %02x%02x, expected 1234\n", recovered[0], recovered[1]);
+      ok = 0;
+    }
+  }
+
+  return ok;
+}
+
+int test_netntlmv1_capture(void)
+{
+  int ok = 1;
+
+  if (!group_a()) ok = 0;
+  if (!group_b()) ok = 0;
+  if (!group_c()) ok = 0;
+  if (!group_d()) ok = 0;
+  if (!group_e()) ok = 0;
+  if (!group_f()) ok = 0;
+
+  return ok;
+}

--- a/tests/test_netntlmv1_capture.h
+++ b/tests/test_netntlmv1_capture.h
@@ -1,0 +1,6 @@
+#ifndef TEST_NETNTLMV1_CAPTURE_H
+#define TEST_NETNTLMV1_CAPTURE_H
+
+int test_netntlmv1_capture(void);
+
+#endif /* TEST_NETNTLMV1_CAPTURE_H */


### PR DESCRIPTION
## Summary
- Adds `-ntlmv1 <capture-or-file>` to `crackalack_lookup`: given a full NetNTLMv1 capture (hashcat `-m 5500` syntax) or a file of them, splits the NT response into its three DES blocks, cracks block1/block2 through the existing rainbow-table pipeline, brute-forces block3's 2-byte key on the CPU (65536 candidates, exhaustive), and reassembles + reports the full 16-byte NTLM hash — no more need to run `ntlmv1-multi` a second time to combine results.
- ESS/NTLM2-Session captures are detected and skipped with a clear message (their random per-session client challenge defeats precomputed tables regardless of the challenge tables were built with).
- Captures whose challenge doesn't match the loaded tables' challenge are also skipped, since tables are challenge-specific.
- The reassembled hash is written to the existing pot files using the verbatim original capture line as the key (real hashcat `-m 5500` pot syntax), so a subsequent hashcat run against the same capture recognizes it as cracked.

Closes larry.spohn's feature request (GitLab issue #1 on the internal instance).

## Implementation
- New self-contained, unit-tested module: `netntlmv1_capture.c/.h` (parsing, ESS detection, block split, block3 brute force, reassembly).
- `crackalack_lookup.c` integration: CLI flag, challenge-filtered capture queueing into the existing lookup pipeline (unmodified), and a post-lookup reassembly pass.
- Documented in `CLAUDE.md` and `README.md`.
- Built via subagent-driven development: 3 tasks, each independently task-reviewed with a fix loop, plus manual end-to-end GPU/Metal verification (real tables, exact-match reassembly, correct ESS short-circuit) and a final whole-branch review with one fix wave.
- Design spec and implementation plan included under `docs/superpowers/specs/` and were committed as part of this work.

## Test plan
- [x] `make cpu-tests && ./crackalack_cpu_tests` — all groups pass, including new NetNTLMv1 capture tests
- [x] `make macos` — clean build, zero warnings
- [x] Manual end-to-end verification on real Metal-generated tables: classic capture reassembles to the exact expected NTLM hash; ESS capture correctly short-circuits with no false positive
- [ ] `make linux`/`make cuda` build verification on a Linux host (not available in this environment — no code is platform-specific, but worth a sanity build before merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)